### PR TITLE
Close topology config file after parsing it.

### DIFF
--- a/src/topology/data.c
+++ b/src/topology/data.c
@@ -121,6 +121,12 @@ static int tplg_parse_data_file(snd_config_t *cfg, struct tplg_elem *elem)
 	elem->data = priv;
 	priv->size = size;
 	elem->size = sizeof(*priv) + size;
+
+	if (fclose(fp) == EOF) {
+		SNDERR("Cannot close data file.");
+		ret = -errno;
+		goto err;
+	}
 	return 0;
 
 err:


### PR DESCRIPTION
In `tplg_parse_data_file()`, a config file is opened but never closed by the function. This patch fixes that.

The error message from Cppcheck is:
`[src\topology\data.c:124] (error) Resource leak: fp [resourceLeak]`
