### PR TITLE
Print unsigned ints with %u instead of %i. (snd_ctl_ascii_elem_id_get)

### DIFF
--- a/src/control/ctlparse.c
+++ b/src/control/ctlparse.c
@@ -126,17 +126,17 @@ char *snd_ctl_ascii_elem_id_get(snd_ctl_elem_id_t *id)
 	device = snd_ctl_elem_id_get_device(id);
 	subdevice = snd_ctl_elem_id_get_subdevice(id);
 	if (index) {
-		snprintf(buf1, sizeof(buf1), ",index=%i", index);
+		snprintf(buf1, sizeof(buf1), ",index=%u", index);
 		if (strlen(buf) + strlen(buf1) < sizeof(buf))
 			strcat(buf, buf1);
 	}
 	if (device) {
-		snprintf(buf1, sizeof(buf1), ",device=%i", device);
+		snprintf(buf1, sizeof(buf1), ",device=%u", device);
 		if (strlen(buf) + strlen(buf1) < sizeof(buf))
 			strcat(buf, buf1);
 	}
 	if (subdevice) {
-		snprintf(buf1, sizeof(buf1), ",subdevice=%i", subdevice);
+		snprintf(buf1, sizeof(buf1), ",subdevice=%u", subdevice);
 		if (strlen(buf) + strlen(buf1) < sizeof(buf))
 			strcat(buf, buf1);
 	}


### PR DESCRIPTION
Cppcheck complains that `snd_ctl_elem_id_get()` is printing unsigned integers with the wrong `printf` format specifier. This patch fixes that.

Cppcheck error below:
```
[src/control/ctlparse.c:129] (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'. [invalidPrintfArgType_sint]
[src/control/ctlparse.c:134] (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'. [invalidPrintfArgType_sint]
[src/control/ctlparse.c:139] (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'. [invalidPrintfArgType_sint]
```
