### PR TITLE
Fix printf format strings in the test programs.

### DIFF
--- a/test/latency.c
+++ b/test/latency.c
@@ -586,7 +586,7 @@ int main(int argc, char *argv[])
 	printf("Capture device is %s\n", cdevice);
 	printf("Parameters are %iHz, %s, %i channels, %s mode\n", rate, snd_pcm_format_name(format), channels, block ? "blocking" : "non-blocking");
 	printf("Poll mode: %s\n", use_poll ? "yes" : "no");
-	printf("Loop limit is %li frames, minimum latency = %i, maximum latency = %i\n", loop_limit, latency_min * 2, latency_max * 2);
+	printf("Loop limit is %lu frames, minimum latency = %i, maximum latency = %i\n", loop_limit, latency_min * 2, latency_max * 2);
 
 	if ((err = snd_pcm_open(&phandle, pdevice, SND_PCM_STREAM_PLAYBACK, block ? 0 : SND_PCM_NONBLOCK)) < 0) {
 		printf("Playback open error: %s\n", snd_strerror(err));

--- a/test/midifile.c
+++ b/test/midifile.c
@@ -295,14 +295,14 @@ find_tempo()
   }
   if (i > tempo_history_count || tempo_history_time[i] > Mf_currtime) {
 #ifdef DEBUG_TIMES
-printf("[past %d, old_tempo %d]\n", tempo_history_time[i], old_tempo);
+printf("[past %lu, old_tempo %lu]\n", tempo_history_time[i], old_tempo);
 #endif
     revised_time = Mf_currtime;
     return(old_tempo);
   }
   tempo_change_time = revised_time = tempo_history_time[i];
 #ifdef DEBUG_TIMES
-printf("[revised_time %d, new_tempo %d]\n", revised_time, new_tempo);
+printf("[revised_time %lu, new_tempo %lu]\n", revised_time, new_tempo);
 #endif
   return(new_tempo);
 }
@@ -376,13 +376,13 @@ readtrack ()			/* read a track chunk */
 	      }
 	    delta_secs = mf_ticks2sec (revised_time-old_currtime, Mf_division, save_tempo);
 #ifdef DEBUG_TIMES
-printf("d(rev %d - old %d, div %d, tempo %d) = %.3f\n",
+printf("d(rev %lu - old %lu, div %d, tempo %lu) = %.3f\n",
 revised_time, old_currtime, Mf_division, save_tempo, delta_secs * 1600.0);
 #endif
 	    Mf_f_realtime = old_f_realtime + delta_secs * 1600.0;
 	    Mf_realtime = (unsigned long)(0.5 + Mf_f_realtime);
 #ifdef DEBUG_TIMES
-printf("\tt=%d ticks ( = %d csec/16 < old %.2f + %.2f)\n", Mf_currtime, Mf_realtime, 
+printf("\tt=%lu ticks ( = %lu csec/16 < old %.2f + %.2f)\n", Mf_currtime, Mf_realtime,
 old_f_realtime, delta_secs * 1600.0);
 #endif
 	      if (revised_time == tempo_change_time) {
@@ -393,13 +393,13 @@ old_f_realtime, delta_secs * 1600.0);
 	    else {
 	    delta_secs = mf_ticks2sec (revised_time-old_currtime, Mf_division, Mf_currtempo);
 #ifdef DEBUG_TIMES
-printf("d(rev %d - old %d, div %d, tempo %d) = %.3f\n",
+printf("d(rev %lu - old %lu, div %d, tempo %lu) = %.3f\n",
 revised_time, old_currtime, Mf_division, Mf_currtempo, delta_secs * 1600.0);
 #endif
 	    Mf_f_realtime = old_f_realtime + delta_secs * 1600.0;
 	    Mf_realtime = (unsigned long)(0.5 + Mf_f_realtime);
 #ifdef DEBUG_TIMES
-printf("\tt=%d ticks ( = %d csec/16 < old %.2f + %.2f)\n", Mf_currtime, Mf_realtime, 
+printf("\tt=%lu ticks ( = %lu csec/16 < old %.2f + %.2f)\n", Mf_currtime, Mf_realtime,
 old_f_realtime, delta_secs * 1600.0);
 #endif
 	    }

--- a/test/mixtest.c
+++ b/test/mixtest.c
@@ -264,7 +264,7 @@ int main(int argc, char **argv)
 		diff = end - begin;
 		if (diff < diffS)
 			diffS = diff;
-		printf("mix_areas_srv : %lld               \r", diff); fflush(stdout);
+		printf("mix_areas_srv : %llu               \r", diff); fflush(stdout);
 	}
 
 	for (t = 0, diff0 = -1; t < LOOP; t++) {
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
 		diff = end - begin;
 		if (diff < diff0)
 			diff0 = diff;
-		printf("mix_areas0    : %lld               \r", diff); fflush(stdout);
+		printf("mix_areas0    : %llu               \r", diff); fflush(stdout);
 	}
 
 	for (t = 0, diff1 = -1; t < LOOP; t++) {
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
 		diff = end - begin;
 		if (diff < diff1)
 			diff1 = diff;
-		printf("mix_areas1    : %lld              \r", diff); fflush(stdout);
+		printf("mix_areas1    : %llu              \r", diff); fflush(stdout);
 	}
 
 	for (t = 0, diff1_mmx = -1; t < LOOP; t++) {
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
 		diff = end - begin;
 		if (diff < diff1_mmx)
 			diff1_mmx = diff;
-		printf("mix_areas1_mmx: %lld              \r", diff); fflush(stdout);
+		printf("mix_areas1_mmx: %llu              \r", diff); fflush(stdout);
 	}
 
 	for (t = 0, diff2 = -1; t < LOOP; t++) {
@@ -316,16 +316,16 @@ int main(int argc, char **argv)
 		diff = end - begin;
 		if (diff < diff2)
 			diff2 = diff;
-		printf("mix_areas2    : %lld              \r", diff); fflush(stdout);
+		printf("mix_areas2    : %llu              \r", diff); fflush(stdout);
 	}
 
 	printf("                                                                           \r");
 	printf("Summary (the best times):\n");
-	printf("mix_areas_srv  : %8lld %f%%\n", diffS, 100*2*44100.0*diffS/(size*n*cpu_clock));
-	printf("mix_areas0     : %8lld %f%%\n", diff0, 100*2*44100.0*diff0/(size*n*cpu_clock));
-	printf("mix_areas1     : %8lld %f%%\n", diff1, 100*2*44100.0*diff1/(size*n*cpu_clock));
-	printf("mix_areas1_mmx : %8lld %f%%\n", diff1_mmx, 100*2*44100.0*diff1_mmx/(size*n*cpu_clock));
-	printf("mix_areas2     : %8lld %f%%\n", diff2, 100*2*44100.0*diff2/(size*n*cpu_clock));
+	printf("mix_areas_srv  : %8llu %f%%\n", diffS, 100*2*44100.0*diffS/(size*n*cpu_clock));
+	printf("mix_areas0     : %8llu %f%%\n", diff0, 100*2*44100.0*diff0/(size*n*cpu_clock));
+	printf("mix_areas1     : %8llu %f%%\n", diff1, 100*2*44100.0*diff1/(size*n*cpu_clock));
+	printf("mix_areas1_mmx : %8llu %f%%\n", diff1_mmx, 100*2*44100.0*diff1_mmx/(size*n*cpu_clock));
+	printf("mix_areas2     : %8llu %f%%\n", diff2, 100*2*44100.0*diff2/(size*n*cpu_clock));
 
 	printf("\n");
 	printf("areas1/srv ratio     : %f\n", (double)diff1 / diffS);

--- a/test/pcm.c
+++ b/test/pcm.c
@@ -49,12 +49,12 @@ static void generate_sine(const snd_pcm_channel_area_t *areas,
 	/* verify and prepare the contents of areas */
 	for (chn = 0; chn < channels; chn++) {
 		if ((areas[chn].first % 8) != 0) {
-			printf("areas[%i].first == %i, aborting...\n", chn, areas[chn].first);
+			printf("areas[%u].first == %u, aborting...\n", chn, areas[chn].first);
 			exit(EXIT_FAILURE);
 		}
 		samples[chn] = /*(signed short *)*/(((unsigned char *)areas[chn].addr) + (areas[chn].first / 8));
 		if ((areas[chn].step % 16) != 0) {
-			printf("areas[%i].step == %i, aborting...\n", chn, areas[chn].step);
+			printf("areas[%u].step == %u, aborting...\n", chn, areas[chn].step);
 			exit(EXIT_FAILURE);
 		}
 		steps[chn] = areas[chn].step / 8;
@@ -127,24 +127,24 @@ static int set_hwparams(snd_pcm_t *handle,
 	/* set the count of channels */
 	err = snd_pcm_hw_params_set_channels(handle, params, channels);
 	if (err < 0) {
-		printf("Channels count (%i) not available for playbacks: %s\n", channels, snd_strerror(err));
+		printf("Channels count (%u) not available for playbacks: %s\n", channels, snd_strerror(err));
 		return err;
 	}
 	/* set the stream rate */
 	rrate = rate;
 	err = snd_pcm_hw_params_set_rate_near(handle, params, &rrate, 0);
 	if (err < 0) {
-		printf("Rate %iHz not available for playback: %s\n", rate, snd_strerror(err));
+		printf("Rate %uHz not available for playback: %s\n", rate, snd_strerror(err));
 		return err;
 	}
 	if (rrate != rate) {
-		printf("Rate doesn't match (requested %iHz, get %iHz)\n", rate, err);
+		printf("Rate doesn't match (requested %uHz, get %iHz)\n", rate, err);
 		return -EINVAL;
 	}
 	/* set the buffer time */
 	err = snd_pcm_hw_params_set_buffer_time_near(handle, params, &buffer_time, &dir);
 	if (err < 0) {
-		printf("Unable to set buffer time %i for playback: %s\n", buffer_time, snd_strerror(err));
+		printf("Unable to set buffer time %u for playback: %s\n", buffer_time, snd_strerror(err));
 		return err;
 	}
 	err = snd_pcm_hw_params_get_buffer_size(params, &size);
@@ -156,7 +156,7 @@ static int set_hwparams(snd_pcm_t *handle,
 	/* set the period time */
 	err = snd_pcm_hw_params_set_period_time_near(handle, params, &period_time, &dir);
 	if (err < 0) {
-		printf("Unable to set period time %i for playback: %s\n", period_time, snd_strerror(err));
+		printf("Unable to set period time %u for playback: %s\n", period_time, snd_strerror(err));
 		return err;
 	}
 	err = snd_pcm_hw_params_get_period_size(params, &size, &dir);
@@ -875,7 +875,7 @@ int main(int argc, char *argv[])
 	}
 
 	printf("Playback device is %s\n", device);
-	printf("Stream parameters are %iHz, %s, %i channels\n", rate, snd_pcm_format_name(format), channels);
+	printf("Stream parameters are %uHz, %s, %u channels\n", rate, snd_pcm_format_name(format), channels);
 	printf("Sine wave rate is %.4fHz\n", freq);
 	printf("Using transfer method: %s\n", transfer_methods[method].name);
 

--- a/test/playmidi1.c
+++ b/test/playmidi1.c
@@ -265,7 +265,7 @@ static void do_noteon(int chan, int pitch, int vol)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: NoteOn (%d) %d %d\n", Mf_currtime, chan, pitch, vol);
+		printf("%lu: NoteOn (%d) %d %d\n", Mf_currtime, chan, pitch, vol);
 	set_event_header(&ev);
 	snd_seq_ev_set_noteon(&ev, chan, pitch, vol);
 	write_ev(&ev);
@@ -277,7 +277,7 @@ static void do_noteoff(int chan, int pitch, int vol)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: NoteOff (%d) %d %d\n", Mf_currtime, chan, pitch, vol);
+		printf("%lu: NoteOff (%d) %d %d\n", Mf_currtime, chan, pitch, vol);
 	set_event_header(&ev);
 	snd_seq_ev_set_noteoff(&ev, chan, pitch, vol);
 	write_ev(&ev);
@@ -289,7 +289,7 @@ static void do_program(int chan, int program)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: Program (%d) %d\n", Mf_currtime, chan, program);
+		printf("%lu: Program (%d) %d\n", Mf_currtime, chan, program);
 	set_event_header(&ev);
 	snd_seq_ev_set_pgmchange(&ev, chan, program);
 	write_ev(&ev);
@@ -301,7 +301,7 @@ static void do_parameter(int chan, int control, int value)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: Control (%d) %d %d\n", Mf_currtime, chan, control, value);
+		printf("%lu: Control (%d) %d %d\n", Mf_currtime, chan, control, value);
 	set_event_header(&ev);
 	snd_seq_ev_set_controller(&ev, chan, control, value);
 	write_ev(&ev);
@@ -313,7 +313,7 @@ static void do_pitchbend(int chan, int lsb, int msb)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: Pitchbend (%d) %d %d\n", Mf_currtime, chan, lsb, msb);
+		printf("%lu: Pitchbend (%d) %d %d\n", Mf_currtime, chan, lsb, msb);
 	set_event_header(&ev);
 	snd_seq_ev_set_pitchbend(&ev, chan, (lsb + (msb << 7)) - 8192);
 	write_ev(&ev);
@@ -324,7 +324,7 @@ static void do_pressure(int chan, int pitch, int pressure)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: KeyPress (%d) %d %d\n", Mf_currtime, chan, pitch, pressure);
+		printf("%lu: KeyPress (%d) %d %d\n", Mf_currtime, chan, pitch, pressure);
 	set_event_header(&ev);
 	snd_seq_ev_set_keypress(&ev, chan, pitch, pressure);
 	write_ev(&ev);
@@ -335,7 +335,7 @@ static void do_chanpressure(int chan, int pressure)
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_EVENT)
-		printf("%ld: ChanPress (%d) %d\n", Mf_currtime, chan, pressure);
+		printf("%lu: ChanPress (%d) %d\n", Mf_currtime, chan, pressure);
 	set_event_header(&ev);
 	snd_seq_ev_set_chanpress(&ev, chan, pressure);
 	write_ev(&ev);
@@ -347,7 +347,7 @@ static void do_sysex(int len, char *msg)
 
 	if (verbose >= VERB_MUCH) {
 		int c;
-		printf("%ld: Sysex, len=%d\n", Mf_currtime, len);
+		printf("%lu: Sysex, len=%d\n", Mf_currtime, len);
 		for (c = 0; c < len; c++) {
 			printf(" %02x", (unsigned char)msg[c]);
 			if (c % 16 == 15)


### PR DESCRIPTION
This fixes several occurrences of the wrong `printf` format specifier being used to print unsigned integral types in the unit tests.

Cppcheck errors below:
```
[test\latency.c:589]: (warning) %li in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\midifile.c:298]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:298]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:305]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:305]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:379]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:379]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:379]: (warning) %d in format string (no. 4) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:385]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:385]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:396]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:396]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:396]: (warning) %d in format string (no. 4) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:402]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned long'.
[test\midifile.c:402]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned long'.
[test\mixtest.c:267]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:280]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:293]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:306]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:319]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:324]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:325]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:326]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:327]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\mixtest.c:328]: (warning) %lld in format string (no. 1) requires 'long long' but the argument type is 'unsigned long long'.
[test\pcm.c:52]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:57]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:130]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:137]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:141]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:147]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:159]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:878]: (warning) %i in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[test\pcm.c:878]: (warning) %i in format string (no. 3) requires 'int' but the argument type is 'unsigned int'.
[test\playmidi1.c:268]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:280]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:292]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:304]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:316]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:327]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:338]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
[test\playmidi1.c:350]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'unsigned long'.
```