### PR TITLE
src/ucm/main.c: fix build without mixer

### DIFF
--- a/src/ucm/main.c
+++ b/src/ucm/main.c
@@ -2115,8 +2115,10 @@ int snd_use_case_parse_selem_id(snd_mixer_selem_id_t *dst,
 				const char *ucm_id,
 				const char *value)
 {
+#ifdef BUILD_MIXER
 	if (strcmp(ucm_id, "PlaybackMixerId") == 0 ||
 	    strcmp(ucm_id, "CaptureMixerId") == 0)
 		return snd_mixer_selem_id_parse(dst, value);
+#endif
 	return -EINVAL;
 }


### PR DESCRIPTION
Commit 4ce38a5ff466d18039b2606938f866ea3a6c9f3c breaks the build without
mixer on:

  CCLD     libasound.la
/home/buildroot/autobuild/instance-1/output-1/host/lib/gcc/xtensa-buildroot-linux-uclibc/8.3.0/../../../../xtensa-buildroot-linux-uclibc/bin/ld: ucm/.libs/libucm.a(main.o): in function `snd_use_case_set':
main.c:(.text+0x185c): undefined reference to `snd_mixer_selem_id_parse'

Fixes:
 - http://autobuild.buildroot.org/results/4d91c9f82a2a61c50c457a851073b85cc09ea345

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>