### PR TITLE
utils/alsa.m4: fix atopology detection without alsatest

### DIFF
--- a/utils/alsa.m4
+++ b/utils/alsa.m4
@@ -124,6 +124,15 @@ exit(0);
    alsa_found=no]
 )
 AC_LANG_RESTORE
+fi
+
+dnl Now that we know that we have the right version, let's see if we have the library and not just the headers.
+if test "x$enable_alsatest" = "xyes"; then
+AC_CHECK_LIB([asound], [snd_ctl_open],,
+	[ifelse([$3], , [AC_MSG_ERROR(No linkable libasound was found.)])
+	 alsa_found=no]
+)
+fi
 
 AC_LANG_SAVE
 AC_LANG_C
@@ -149,20 +158,11 @@ exit(0);
 )
 AC_LANG_RESTORE
 
-fi
-
-dnl Now that we know that we have the right version, let's see if we have the library and not just the headers.
-if test "x$enable_alsatest" = "xyes"; then
-AC_CHECK_LIB([asound], [snd_ctl_open],,
-	[ifelse([$3], , [AC_MSG_ERROR(No linkable libasound was found.)])
-	 alsa_found=no]
-)
 if test "x$enable_atopology" = "xyes"; then
 AC_CHECK_LIB([atopology], [snd_tplg_new],,
 	[ifelse([$3], , [AC_MSG_ERROR(No linkable libatopology was found.)])
 	 alsa_found=no]
 )
-fi
 fi
 
 if test "x$alsa_found" = "xyes" ; then


### PR DESCRIPTION
Since commit 75d393a563efb578c79364a277087c6326267f52, alsa-utils fails
to build with --disable-alsatest because atopology is not detected

Fixes:
 - http://autobuild.buildroot.org/results/d0fb760669b02b813115af04adcf24530d35f4e1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>