### PR TITLE
configure.ac: remove an unnecessary libtool fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -764,14 +764,3 @@ test "$build_seq" = "yes" && echo "#include <alsa/seq.h>" >> include/asoundlib.h
 test "$build_seq" = "yes" && echo "#include <alsa/seqmid.h>" >> include/asoundlib.h
 test "$build_seq" = "yes" && echo "#include <alsa/seq_midi_event.h>" >> include/asoundlib.h
 cat "$srcdir"/include/asoundlib-tail.h >> include/asoundlib.h
-
-dnl Taken from https://wiki.debian.org/RpathIssue
-case $host in
-   *-*-linux-gnu)
-   AC_MSG_RESULT([Fixing libtool for -rpath problems.])
-   sed < libtool > libtool-2 \
-     's/^hardcode_libdir_flag_spec.*$'/'hardcode_libdir_flag_spec=" -D__LIBTOOL_IS_A_FOOL__ "/'
-   mv libtool-2 libtool
-   chmod 755 libtool
- ;;
-esac


### PR DESCRIPTION
This code was added in commit 75d393a563efb578c79364a277087c6326267f52
without explaining why. I assume it was a mistake, since it looks like
the libtool problem should have gone away a long time ago. The referenced
wiki page https://wiki.debian.org/RpathIssue says:

    Since libtool 1.5.2 (released 2004-01-25), on Linux libtool no
    longer sets RPATH for any directories in the dynamic linker search
    path, so this should no longer be an issue unless upstream used a
    really old version of libtool when creating their distribution
    tarball.

This code caused problems in OpenEmbedded, where the libtool script is
named "x86_64-oe-linux-libtool" or similar rather than just "libtool",
so the sed command failed with a file not found error. Rather than
adapting the code to OpenEmbedded's peculiarities, it seems best to just
remove the unnecessary code altogether.

Signed-off-by: Tanu Kaskinen <tanuk@iki.fi>