### PR TITLE
mixer: Fix memory leak for more than 16 file descriptor case

### DIFF
--- a/src/mixer/mixer.c
+++ b/src/mixer/mixer.c
@@ -767,7 +767,7 @@ int snd_mixer_wait(snd_mixer_t *mixer, int timeout)
 	if (count < 0)
 		return count;
 	if ((unsigned int) count > sizeof(spfds) / sizeof(spfds[0])) {
-		pfds = malloc(count * sizeof(*pfds));
+		pfds = alloca(count * sizeof(*pfds));
 		if (!pfds)
 			return -ENOMEM;
 		err = snd_mixer_poll_descriptors(mixer, pfds, 


### PR DESCRIPTION
I saw this when digging through the source code, wrote up a test case, and verified with valgrind.  I don't have that many sound cards so I modified mixer.c to always take the conditional.  alloca seemed like the least effort way to fix this.  Other thoughts were to test pfds != spfds and free, but given how little bytes would be allocated putting on the stack seems reasonable.