### PR TITLE
CRAS UCMs V2

### DIFF
--- a/include/use-case.h
+++ b/include/use-case.h
@@ -349,6 +349,9 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *   - CoupledMixers
  *      - Mixer controls that should be changed together.
  *        E.g. "Left Master,Right Master".
+ *   - EchoReferencePCM
+ *      - If userspace wants an echo reference channel this value identifies
+ *        the pcm to be used.
  *   - EDIDFile
  *      - Path to EDID file for HDMI devices
  *   - JackCTL

--- a/include/use-case.h
+++ b/include/use-case.h
@@ -346,6 +346,9 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *      - Remap channels using ALSA PCM channel mapping API notation
  *        E.g. "2 3 0 1 -1 -1 -1 -1 -1 -1 -1" means, FL takes channel 2,
  *        FR takes channel 3, RL takes channel 0, RL takes channel 1.
+ *   - CoupledMixers
+ *      - Mixer controls that should be changed together.
+ *        E.g. "Left Master,Right Master".
  *   - EDIDFile
  *      - Path to EDID file for HDMI devices
  *   - JackCTL

--- a/include/use-case.h
+++ b/include/use-case.h
@@ -342,6 +342,10 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *   - CaptureMasterType
  *      - type of the master volume control
  *      - Valid values: "soft" (software attenuation)
+ *   - CaptureChannelMap
+ *      - Remap channels using ALSA PCM channel mapping API notation
+ *        E.g. "2 3 0 1 -1 -1 -1 -1 -1 -1 -1" means, FL takes channel 2,
+ *        FR takes channel 3, RL takes channel 0, RL takes channel 1.
  *   - EDIDFile
  *      - Path to EDID file for HDMI devices
  *   - JackCTL


### PR DESCRIPTION
v2 changes
Dropped Jack* as it looks like we may need to do some renaming internally.
Dropped Gain controls as we are adjusting our definitions.
Dropped disable software volume per comments and will look at removing internally

Notes:
Per request regarding CaptureChannelMap, is it work changing the format if the current format transfers directly to alsa plugin inputs?

Apologies for the multi month delay between versions