### PR TITLE
Quote strings containing [ or ] when saving an alsa config

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1531,6 +1531,8 @@ static void string_print(char *str, int id, snd_output_t *out)
 	case '.':
 	case '{':
 	case '}':
+	case '[':
+	case ']':
 	case '\'':
 	case '"':
 		goto quoted;


### PR DESCRIPTION
This pull request will fix issue #22.

When saving the configuration for a control, values containing square brackets should be quoted. Please review and test as this code hasn't been tested yet. 

Note: does the '+' character also need quotes? If so, now might be a good time to add it to this list.