### PR TITLE
Remove duplicate surround entries. Fix for #27

### DIFF
--- a/src/conf/alsa.conf
+++ b/src/conf/alsa.conf
@@ -315,6 +315,15 @@ pcm.surround41 cards.pcm.surround41
 pcm.surround50 cards.pcm.surround50
 pcm.surround51 cards.pcm.surround51
 pcm.surround71 cards.pcm.surround71
+
+# Remove duplicate surround entries
+defaults.pcm.!surround21 0
+defaults.pcm.!surround40 0
+defaults.pcm.!surround41 0
+defaults.pcm.!surround50 0
+defaults.pcm.!surround51 0
+defaults.pcm.!surround71 0
+
 pcm.iec958 cards.pcm.iec958
 pcm.spdif iec958
 pcm.hdmi cards.pcm.hdmi


### PR DESCRIPTION
Try to remove duplicate surround entries to fix crashes with certain apps by changing the config a bit.
This would have multiple benefits.
1. It allows all the bonus devices (such as samplerate) gained from Version 1.2.2 to stay.
2. It still keeps surround devices around, just removes duplicate entries if they exist.
3. It fixes Issue #27 and all Unity3D-based games.
I'm not sure about side effects tho, but they seem to be reasonably low from what I've tested.
Thanks for taking a look.