### PR TITLE
conf: namehint - add noargs to the hint section

### DIFF
--- a/src/conf/pcm/surround21.conf
+++ b/src/conf/pcm/surround21.conf
@@ -57,5 +57,6 @@ pcm.!surround21 {
 	hint {
 		description "2.1 Surround output to Front and Subwoofer speakers"
 		device_output $DEV
+		omit_noargs true
 	}
 }

--- a/src/conf/pcm/surround40.conf
+++ b/src/conf/pcm/surround40.conf
@@ -55,5 +55,6 @@ pcm.!surround40 {
 	hint {
 		description "4.0 Surround output to Front and Rear speakers"
 		device_output $DEV
+		omit_noargs true
 	}
 }

--- a/src/conf/pcm/surround41.conf
+++ b/src/conf/pcm/surround41.conf
@@ -61,5 +61,6 @@ pcm.!surround41 {
 	hint {
 		description "4.1 Surround output to Front, Rear and Subwoofer speakers"
 		device_output $DEV
+		omit_noargs true
 	}
 }

--- a/src/conf/pcm/surround50.conf
+++ b/src/conf/pcm/surround50.conf
@@ -61,5 +61,6 @@ pcm.!surround50 {
 	hint {
 		description "5.0 Surround output to Front, Center and Rear speakers"
 		device_output $DEV
+		omit_noargs true
 	}
 }

--- a/src/conf/pcm/surround51.conf
+++ b/src/conf/pcm/surround51.conf
@@ -57,5 +57,6 @@ pcm.!surround51 {
 	hint {
 		description "5.1 Surround output to Front, Center, Rear and Subwoofer speakers"
 		device_output $DEV
+		omit_noargs true
 	}
 }

--- a/src/conf/pcm/surround71.conf
+++ b/src/conf/pcm/surround71.conf
@@ -59,5 +59,6 @@ pcm.!surround71 {
 	hint {
 		description "7.1 Surround output to Front, Center, Side, Rear and Woofer speakers"
 		device_output $DEV
+		omit_noargs true
 	}
 }

--- a/src/control/namehint.c
+++ b/src/control/namehint.c
@@ -287,10 +287,14 @@ static int try_config(snd_config_t *config,
 			err = -EINVAL;
 			goto __cleanup;
 		}
+		if (list->card < 0 &&
+		    snd_config_search(cfg, "omit_noargs", &n) >= 0 &&
+		    snd_config_get_bool(n) > 0)
+			goto __skip_add;
 		if (level == 1 &&
 		    snd_config_search(cfg, "show", &n) >= 0 &&
 		    snd_config_get_bool(n) <= 0)
-		    	goto __skip_add;
+			goto __skip_add;
 		if (buf1 == NULL &&
 		    snd_config_search(cfg, "description", &n) >= 0 &&
 		    snd_config_get_string(n, &str) >= 0) {


### PR DESCRIPTION
Do not list simple surround devices in the namehint section by default.

Fixes: https://github.com/alsa-project/alsa-lib/issues/27
