### PR TITLE
conf: USB-Audio: Add C-Media USB Headphone Set to the IEC958 blacklist

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -44,6 +44,7 @@ USB-Audio.pcm.iec958_device {
 	# The below don't have digital in/out, so prevent them from being opened.
 	"Andrea PureAudio USB-SA Headset" 999
 	"Blue Snowball" 999
+	"C-Media USB Headphone Set" 999
 	"HP Digital Stereo Headset" 999
 	"GN 9330" 999
 	"Logitech Speaker Lapdesk N700" 999


### PR DESCRIPTION
Fixes: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/317

Signed-off-by: Tanu Kaskinen <tanuk@iki.fi>