### PR TITLE
conf: USB-Audio: Fix S/PDIF output of ASUS Xonar AE

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -40,6 +40,7 @@ USB-Audio.pcm.iec958_device {
 	"USB Sound Blaster HD" 1
 	"Xonar U7" 1
 	"ASUS XONAR U5" 1
+	"XONAR SOUND CARD" 1
 	
 	# The below don't have digital in/out, so prevent them from being opened.
 	"Andrea PureAudio USB-SA Headset" 999


### PR DESCRIPTION
ASUS Xonar AE is a PCI-Express card containing USB controller:

	USB controller [0c03]: ASMedia Technology Inc. ASM1042A USB 3.0 Host Controller [1b21:1142]

and the actual USB sound card:

	ID 0b05:180f ASUSTek Computer, Inc. XONAR SOUND CARD

As other Xonar USB sound cards, it uses second device for digital
output.

Signed-off-by: Ivan Mironov <mironov.ivan@gmail.com>