### PR TITLE
pcm: Fix memory leak at snd_pcm_new when THREAD_SAVE_API is defined

### DIFF
--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -2745,6 +2745,7 @@ int snd_pcm_new(snd_pcm_t **pcmp, snd_pcm_type_t type, const char *name,
 	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 #endif
 	pthread_mutex_init(&pcm->lock, &attr);
+	pthread_mutexattr_destroy(&attr);
 	/* use locking as default;
 	 * each plugin may suppress this in its open call
 	 */


### PR DESCRIPTION
The pthread_mutexattr_t object should be destroyed by calling
pthread_mutexattr_destroy(), otherwise it may cause a potential
memory leak due to the different implement of pthread_mutexattr_init()

Signed-off-by: chunxu.li <chunxuxiao@gmail.com>