### PR TITLE
ucm: initialize mgr->once_list

### DIFF
--- a/src/ucm/main.c
+++ b/src/ucm/main.c
@@ -960,6 +960,7 @@ int snd_use_case_mgr_open(snd_use_case_mgr_t **uc_mgr,
 	if (mgr == NULL)
 		return -ENOMEM;
 	INIT_LIST_HEAD(&mgr->verb_list);
+	INIT_LIST_HEAD(&mgr->once_list);
 	INIT_LIST_HEAD(&mgr->default_list);
 	INIT_LIST_HEAD(&mgr->value_list);
 	INIT_LIST_HEAD(&mgr->active_modifiers);


### PR DESCRIPTION
Initiliaze mgr->once_list otherwise eg `alsactl restore 0` will segfault in https://github.com/alsa-project/alsa-lib/blob/master/src/ucm/utils.c#L570 in case that  `/var/lib/alsa/alsa.state` is not present.