### PR TITLE
dlmisc.c: fix uclibc build

### DIFF
--- a/src/dlmisc.c
+++ b/src/dlmisc.c
@@ -69,7 +69,7 @@ static inline void snd_dlpath_unlock(void) {}
 int snd_dlpath(char *path, size_t path_len, const char *name)
 {
 #ifdef HAVE_LIBDL
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
 	static int plugin_dir_set = 0;
 	snd_dlpath_lock();
 	if (!plugin_dir_set) {


### PR DESCRIPTION
RTLD_DL_LINKMAP & RTLD_DI_ORIGIN, are unsupported on uClibc:
https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/include/dlfcn.h#n106

This patch adds detection for uClibc because uClibc also defines
__GLIBC__:
https://lists.gnu.org/archive/html/bug-gnulib/2010-11/msg00280.html