### PR TITLE
pcm: direct: correctly apply existing interval settings

### DIFF
--- a/src/pcm/pcm_direct.c
+++ b/src/pcm/pcm_direct.c
@@ -929,10 +929,14 @@ int snd_pcm_direct_hw_refine(snd_pcm_t *pcm, snd_pcm_hw_params_t *params)
 			return err;
 		if (dshare->var_periodsize) {
 			/* more tolerant settings... */
-			if (dshare->shmptr->hw.buffer_size.max / 2 > period_size.max)
+			if (dshare->shmptr->hw.buffer_size.max / 2 > period_size.max) {
 				period_size.max = dshare->shmptr->hw.buffer_size.max / 2;
-			if (dshare->shmptr->hw.buffer_time.max / 2 > period_time.max)
+				period_size.openmax = dshare->shmptr->hw.buffer_size.openmax;
+			}
+			if (dshare->shmptr->hw.buffer_time.max / 2 > period_time.max) {
 				period_time.max = dshare->shmptr->hw.buffer_time.max / 2;
+				period_time.openmax = dshare->shmptr->hw.buffer_time.openmax;
+			}
 		}
 
 		err = hw_param_interval_refine_one(params, SND_PCM_HW_PARAM_PERIOD_SIZE,


### PR DESCRIPTION
Feature 'variable periodsize' allows to extend user period size up to buffer_size/2 independent of slave period.
On enlargement of the settings for period_time.max and period_size.max the setting for openmax was not updated.

This lead to the effect, that if the slave period itself had openmax set it was still set on the extended size.
Configuration of a period matching half buffer size was thus rejected.

Example for failure: period size of 384 (half buffer size) is requested which is rejected and rounded down to 352:

<pre>
root@oracle-virtualbox:~# arecord -DDSNOOP_32 -r48000 -fS16_LE -c2 --period-size=382 -vv --dump-hw-params > /dev/null
Recording WAVE 'stdin' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
HW Params of device "DSNOOP_32":
--------------------
ACCESS:  MMAP_INTERLEAVED MMAP_NONINTERLEAVED RW_INTERLEAVED RW_NONINTERLEAVED
FORMAT:  S16_LE
SUBFORMAT:  STD
SAMPLE_BITS: 16
FRAME_BITS: 32
CHANNELS: 2
RATE: 48000
PERIOD_TIME: (666 7334)
PERIOD_SIZE: [32 352]
PERIOD_BYTES: [128 1408]
PERIODS: [2 24]
BUFFER_TIME: (1333 16000]
BUFFER_SIZE: [64 768]
BUFFER_BYTES: [256 3072]
TICK_TIME: ALL
--------------------
Direct Snoop PCM
Its setup is:
  stream       : CAPTURE
  access       : RW_INTERLEAVED
  format       : S16_LE
  subformat    : STD
  channels     : 2
  rate         : 48000
  exact rate   : 48000 (48000/1)
  msbits       : 16
  buffer_size  : 704
  period_size  : 352
  period_time  : 7333
  tstamp_mode  : NONE
  tstamp_type  : MONOTONIC
  period_step  : 1
  avail_min    : 352
  period_event : 0
  start_threshold  : 1
  stop_threshold   : 704
  silence_threshold: 0
  silence_size : 0
  boundary     : 6341068275337658368
Hardware PCM card 0 'Intel 82801AA-ICH' device 0 subdevice 0
Its setup is:
  stream       : CAPTURE
  access       : MMAP_INTERLEAVED
  format       : S16_LE
  subformat    : STD
  channels     : 2
  rate         : 48000
  exact rate   : 48000 (48000/1)
  msbits       : 16
  buffer_size  : 768
  period_size  : 32
  period_time  : 666
  tstamp_mode  : ENABLE
  tstamp_type  : MONOTONIC
  period_step  : 1
  avail_min    : 32
  period_event : 0
  start_threshold  : 1
  stop_threshold   : 6917529027641081856
  silence_threshold: 0
  silence_size : 0
  boundary     : 6917529027641081856
  appl_ptr     : 0
  hw_ptr       : 224

When correctly applying the openmax setting:

root@oracle-virtualbox:~# arecord -DDSNOOP_32 -r48000 -fS16_LE -c2 --period-size=382 -vv --dump-hw-params > /dev/null
Recording WAVE 'stdin' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
HW Params of device "DSNOOP_32":
--------------------
ACCESS:  MMAP_INTERLEAVED MMAP_NONINTERLEAVED RW_INTERLEAVED RW_NONINTERLEAVED
FORMAT:  S16_LE
SUBFORMAT:  STD
SAMPLE_BITS: 16
FRAME_BITS: 32
CHANNELS: 2
RATE: 48000
PERIOD_TIME: (666 8000]
PERIOD_SIZE: [32 384]
PERIOD_BYTES: [128 1536]
PERIODS: [2 24]
BUFFER_TIME: (1333 16000]
BUFFER_SIZE: [64 768]
BUFFER_BYTES: [256 3072]
TICK_TIME: ALL
--------------------
Direct Snoop PCM
Its setup is:
  stream       : CAPTURE
  access       : RW_INTERLEAVED
  format       : S16_LE
  subformat    : STD
  channels     : 2
  rate         : 48000
  exact rate   : 48000 (48000/1)
  msbits       : 16
  buffer_size  : 768
  period_size  : 384
  period_time  : 8000
  tstamp_mode  : NONE
  tstamp_type  : MONOTONIC
  period_step  : 1
  avail_min    : 384
  period_event : 0
  start_threshold  : 1
  stop_threshold   : 768
  silence_threshold: 0
  silence_size : 0
  boundary     : 6917529027641081856
Hardware PCM card 0 'Intel 82801AA-ICH' device 0 subdevice 0
Its setup is:
  stream       : CAPTURE
  access       : MMAP_INTERLEAVED
  format       : S16_LE
  subformat    : STD
  channels     : 2
  rate         : 48000
  exact rate   : 48000 (48000/1)
  msbits       : 16
  buffer_size  : 768
  period_size  : 32
  period_time  : 666
  tstamp_mode  : ENABLE
  tstamp_type  : MONOTONIC
  period_step  : 1
  avail_min    : 32
  period_event : 0
  start_threshold  : 1
  stop_threshold   : 6917529027641081856
  silence_threshold: 0
  silence_size : 0
  boundary     : 6917529027641081856
  appl_ptr     : 0
  hw_ptr       : 224
</pre>

Signed-off-by: Andreas Pape <apape@de.adit-jv.com>