### PR TITLE
alsa-lib: ctl: improve documentation for identifier of control element

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -49,8 +49,8 @@ are managed according to below model.
    - An element includes some members to have a value. The value of each member
      can be changed by both of userspace applications and drivers in kernel.
 
-Each element can be identified by two ways; a combination of name and index, or
-numerical number (numid).
+Each element can be identified by two ways; the numerical number (numid), or the
+combination of interface, device, subdevice, name, and index.
 
 The type of element set is one of integer, integerr64, boolean, enumerators,
 bytes and IEC958 structure. This indicates the type of value for each member in


### PR DESCRIPTION
In documentation, there are two ways relevant to the identifier of control
element. However, the case of combination has the lack of parameters.

This commit improves documentation in this point.

Fixes: f3c24de8c0df ("ctl: add an overview for design of ALSA control interface")
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>