### PR TITLE
S/PDIF fix for Asus Xonar SE Output

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -42,6 +42,7 @@ USB-Audio.pcm.iec958_device {
 	"ASUS XONAR U5" 1
 	"XONAR U5" 1
 	"XONAR SOUND CARD" 1
+	"Xonar SoundCard" 2
 	
 	# The below don't have digital in/out, so prevent them from being opened.
 	"Andrea PureAudio USB-SA Headset" 999


### PR DESCRIPTION
The ASUS Xonar SE soundcard (ID 0b05:189d ASUSTek Computer, Inc. Xonar SoundCard) defaults to the first device for S/PDIF when it should actually use the third for its digital output.

This fix was discussed in this AskUbuntu post: https://askubuntu.com/a/1210401/117741.

Signed-off by: Omar Dzinic <odzinic@gmail.com>