### PR TITLE
ucm: let rval_sysfs check the device/driver/module first

### DIFF
--- a/src/ucm/ucm_subs.c
+++ b/src/ucm/ucm_subs.c
@@ -202,9 +202,12 @@ static char *rval_sysfs(snd_use_case_mgr_t *uc_mgr ATTRIBUTE_UNUSED, const char 
 		e = "/sys";
 	if (id[0] == '/')
 		id++;
-	snprintf(path, sizeof(path), "%s/%s", e, id);
-	if (lstat(path, &sb) != 0)
-		return NULL;
+	snprintf(path, sizeof(path), "%s/%s/%s", e, id, "module");
+	if (lstat(path, &sb) != 0) {
+		snprintf(path, sizeof(path), "%s/%s", e, id);
+		if (lstat(path, &sb) != 0)
+			return NULL;
+	}
 	if (S_ISLNK(sb.st_mode)) {
 		len = readlink(path, link, sizeof(link) - 1);
 		if (len <= 0) {


### PR DESCRIPTION
We plan to use the sound driver module's name for the top ucm's name,
I checked it on 3 different ASoC machines, the device/driver links to
machine driver while deice/driver/module links to the sound driver
module, so change the code to readlink the device/driver/module first,
if it fails then readlink the device/driver.

This is the output from those 3 machines:
$readlink /sys/class/sound/card0/device/driver
../../../../bus/platform/drivers/skl_hda_dsp_generic
$readlink /sys/class/sound/card0/device/driver/module
../../../../module/snd_soc_skl_hda_dsp

$readlink /sys/class/sound/card2/device/driver
../../../../../bus/platform/drivers/acp_pdm_mach
$readlink /sys/class/sound/card2/device/driver/module
../../../../module/snd_acp3x_rn

$readlink /sys/class/sound/card0/device/driver
../../../../bus/platform/drivers/sof_sdw
$readlink /sys/class/sound/card0/device/driver/module
../../../../module/snd_soc_sof_sdw

Signed-off-by: Hui Wang <hui.wang@canonical.com>