### PR TITLE
ucm: return error if boot_list is empty

### DIFF
--- a/src/ucm/main.c
+++ b/src/ucm/main.c
@@ -1895,6 +1895,8 @@ static int set_boot_user(snd_use_case_mgr_t *uc_mgr,
 		uc_error("error: wrong value for _boot (%s)", value);
 		return -EINVAL;
 	}
+	if (list_empty(&uc_mgr->boot_list))
+		return -ENOENT;
 	err = execute_sequence(uc_mgr, &uc_mgr->boot_list,
 			       &uc_mgr->value_list, NULL, NULL);
 	if (err < 0) {


### PR DESCRIPTION
If bootlist is empty, that means there is no BootSequence defined
in the ucm for this sound card, let set_boot_user() return error,
then alsactl could have chance to use non-ucm ways to initialize the
sound card.

Signed-off-by: Hui Wang <hui.wang@canonical.com>