### PR TITLE
pcm: snd_pcm_readi - plugin type multi, the overun appears when read

### DIFF
--- a/src/pcm/pcm_plugin.c
+++ b/src/pcm/pcm_plugin.c
@@ -498,6 +498,7 @@ static snd_pcm_sframes_t snd_pcm_plugin_avail_update(snd_pcm_t *pcm)
 			 * there is more data available.
 			 */
 			slave_size = snd_pcm_avail_update(slave);
+			slave_frames = slave_size;
 			result = snd_pcm_mmap_begin(slave, &slave_areas, &slave_offset, &slave_frames);
 			if (result < 0) {
 				err = result;


### PR DESCRIPTION
After type route use type multi, merge the two input streams.There was
PCM error due to insufficient readable data.Cause the underlying read
pointer cannot be updated, and then it will be overrun.