### PR TITLE
conf: HDA-Intel: increase the max number of HDMI/DP output to 11

### DIFF
--- a/src/conf/cards/HDA-Intel.conf
+++ b/src/conf/cards/HDA-Intel.conf
@@ -398,6 +398,75 @@ HDA-Intel.pcm.hdmi.7 {
 	}
 }
 
+HDA-Intel.pcm.hdmi.8 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	@func refer
+	name {
+		@func concat
+		strings [
+			"cards.HDA-Intel.pcm.hdmi.common:"
+			"CARD=" $CARD ","
+			"DEVICE=14,"
+			"CTLINDEX=8,"
+			"AES0=" $AES0 ","
+			"AES1=" $AES1 ","
+			"AES2=" $AES2 ","
+			"AES3=" $AES3
+		]
+	}
+}
+
+HDA-Intel.pcm.hdmi.9 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	@func refer
+	name {
+		@func concat
+		strings [
+			"cards.HDA-Intel.pcm.hdmi.common:"
+			"CARD=" $CARD ","
+			"DEVICE=15,"
+			"CTLINDEX=9,"
+			"AES0=" $AES0 ","
+			"AES1=" $AES1 ","
+			"AES2=" $AES2 ","
+			"AES3=" $AES3
+		]
+	}
+}
+
+HDA-Intel.pcm.hdmi.10 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD { type string }
+	@args.AES0 { type integer }
+	@args.AES1 { type integer }
+	@args.AES2 { type integer }
+	@args.AES3 { type integer }
+	@func refer
+	name {
+		@func concat
+		strings [
+			"cards.HDA-Intel.pcm.hdmi.common:"
+			"CARD=" $CARD ","
+			"DEVICE=16,"
+			"CTLINDEX=10,"
+			"AES0=" $AES0 ","
+			"AES1=" $AES1 ","
+			"AES2=" $AES2 ","
+			"AES3=" $AES3
+		]
+	}
+}
+
 <confdir:pcm/modem.conf>
 
 HDA-Intel.pcm.modem.0 {


### PR DESCRIPTION
Intel TGL HDMI/DP codec provides 9 pins (Linux kernel, 9a11ba7388f16:
ALSA: hda: hdmi - add Tigerlake support), and with the DP MST enabled,
the linux kernel will build 11 output devices (3, 7, 8, 9, 10, 11, 12,
13, 14, 15, 16), and current alsa-lib only maps the first 8 output
devices, if users plug the HDMI/DP monitor to the last 4 ports, the
users will not see the output device from pulseaudio or gnome.

We have experienced this issue on a dell TGL machine with a dock, we
plugged 2 HDMP/DP monitors on the dock, but we could only see 1
HDMI/DP output device from pulseaudio or gnome, through investigation,
we found one monitor is plugged in the 2nd port from last.

Signed-off-by: Hui Wang <hui.wang@canonical.com>