### PR TITLE
conf: USB - add "Cmedia Audio" to USB-Audio.pcm.iec958_device

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -49,6 +49,7 @@ USB-Audio.pcm.iec958_device {
 	"Andrea PureAudio USB-SA Headset" 999
 	"Blue Snowball" 999
 	"C-Media USB Headphone Set" 999
+	"Cmedia Audio" 999
 	"HP Digital Stereo Headset" 999
 	"GN 9330" 999
 	"Logitech Speaker Lapdesk N700" 999


### PR DESCRIPTION
Otherwise, there will be a "Digital Output(S/PDIF)-Cmedia Audio" from
Gnome UI, but there is no this physical interface on the card.

Signed-off-by: Hui Wang <hui.wang@canonical.com>