### PR TITLE
conf: Remove non-existent SPDIF output on Dell AE515

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -49,6 +49,7 @@ USB-Audio.pcm.iec958_device {
 	"Andrea PureAudio USB-SA Headset" 999
 	"Blue Snowball" 999
 	"C-Media USB Headphone Set" 999
+	"DELL PROFESSIONAL SOUND BAR AE5" 999
 	"HP Digital Stereo Headset" 999
 	"GN 9330" 999
 	"Logitech Speaker Lapdesk N700" 999


### PR DESCRIPTION
The Dell Professional Sound Bar AE515 shows up in GNOME Settings with a digital output that doesn't physically exist. Add it to the list to suppress this.