### PR TITLE
pcm: dshare - fix shared memory pointer check

### DIFF
--- a/src/pcm/pcm_dshare.c
+++ b/src/pcm/pcm_dshare.c
@@ -719,6 +719,7 @@ int snd_pcm_dshare_open(snd_pcm_t **pcmp, const char *name,
 	dshare->tstamp_type = opts->tstamp_type;
 	dshare->semid = -1;
 	dshare->shmid = -1;
+	dshare->shmptr = (void *) -1;
 
 	ret = snd_pcm_new(&pcm, dshare->type = SND_PCM_TYPE_DSHARE, name, stream, mode);
 	if (ret < 0)
@@ -875,7 +876,7 @@ int snd_pcm_dshare_open(snd_pcm_t **pcmp, const char *name,
 	return 0;
 	
  _err:
-	if (dshare->shmptr)
+	if (dshare->shmptr != (void *) -1)
 		dshare->shmptr->u.dshare.chn_mask &= ~dshare->u.dshare.chn_mask;
 	if (dshare->timer)
 		snd_timer_close(dshare->timer);


### PR DESCRIPTION
Currently shared memory pointer is initialized to 0 and set to -1
in some, but not in all error paths.
In cleanup path of open the shm pointer is only compared to be non-NULL
before dereferencing it which leads to SEGFAULT in case it was set to -1.

This patch initializes pointer to -1 to have a unique identification
for invalid pointer and also checks for pointer being not -1 on
access in cleanup path.

Signed-off-by: Vanitha Channaiah <vanitha.channaiah@in.bosch.com>