### PR TITLE
Intro and prep for Topology2.0

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -124,6 +124,8 @@ int snd_config_copy(snd_config_t **dst, snd_config_t *src);
 
 int snd_config_make(snd_config_t **config, const char *key,
 		    snd_config_type_t type);
+int snd_config_make_add(snd_config_t **config, char *id,
+			snd_config_type_t type, snd_config_t *parent);
 int snd_config_make_integer(snd_config_t **config, const char *key);
 int snd_config_make_integer64(snd_config_t **config, const char *key);
 int snd_config_make_real(snd_config_t **config, const char *key);

--- a/include/global.h
+++ b/include/global.h
@@ -153,6 +153,19 @@ typedef struct timeval snd_timestamp_t;
 /** Hi-res timestamp */
 typedef struct timespec snd_htimestamp_t;
 
+/**
+ * \brief Copy a C-string into a sized buffer
+ * \param dst Where to copy the string to
+ * \param src Where to copy the string from
+ * \param size Size of destination buffer
+ * \retval The source string length
+ *
+ * The result is always a valid NUL-terminated string that fits
+ * in the buffer (unless, of course, the buffer size is zero).
+ * It does not pad out the result like strncpy() does.
+ */
+size_t snd_strlcpy(char *dst, const char *src, size_t size);
+
 /** \} */
 
 #ifdef __cplusplus

--- a/include/local.h
+++ b/include/local.h
@@ -236,7 +236,6 @@ int safe_strtol(const char *str, long *val);
 
 int snd_send_fd(int sock, void *data, size_t len, int fd);
 int snd_receive_fd(int sock, void *data, size_t len, int *fd);
-size_t snd_strlcpy(char *dst, const char *src, size_t size);
 
 /*
  * error messages

--- a/src/conf.c
+++ b/src/conf.c
@@ -2310,6 +2310,47 @@ int snd_config_make(snd_config_t **config, const char *id,
 }
 
 /**
+ * \brief Creates a configuration node and add it to the parent node.
+ * \param[out] config The function puts the handle to the new node at
+ *                    the address specified by \a config.
+ * \param[in] id The id of the new node.
+ * \param[in] type The type of the new node.
+ * \param[in] parent handle for the parent node.
+ * \return Zero if successful, otherwise a negative error code.
+ *
+ * This functions creates a new node of the specified type.
+ * The new node has id \a id, which may be \c NULL.
+ * and adds it to the parent node.
+ *
+ * The value of the new node is zero (for numbers), or \c NULL (for
+ * strings and pointers), or empty (for compound nodes).
+ *
+ * \par Errors:
+ * <dl>
+ * <dt>-ENOMEM<dd>Out of memory.
+ * </dl>
+ */
+int snd_config_make_add(snd_config_t **config, char *id,
+		    snd_config_type_t type, snd_config_t *parent)
+{
+	char *id1;
+	int ret;
+
+	assert(config);
+	if (id) {
+		id1 = strdup(id);
+		if (!id1)
+			return -ENOMEM;
+	} else
+		id1 = NULL;
+	ret = _snd_config_make(config, &id1, type);
+	if (ret < 0)
+		return ret;
+
+	return snd_config_add(parent, *config);
+}
+
+/**
  * \brief Creates an integer configuration node.
  * \param[out] config The function puts the handle to the new node at
  *                    the address specified by \a config.


### PR DESCRIPTION
This pull request includes the preparatory commits paving the way for introducing Topology2.0. Existing alsatplg compiler
functionality is unmodified.

An example implementation of topology with Topology2.0 can be found here:
https://github.com/thesofproject/sof/pull/3936

   **Introduction to Topology 2.0**
    -----

    Topology2.0 is a high level keyword extension on top of the existing ALSA
    conf topology format designed to:

    1) Simplify the ALSA conf topology definitions by providing high level
       "classes" so topology designers need to write less config for common
       object definitions.

    2) Allow simple reuse of objects. Define once and reuse (like M4) with
       the ability to alter objects configuration attributes from defaults.

    3) Allow data type and value verification. This is not done today and
       frequently crops up in FW bug reports.

    **Common Topology Classes**
    -----------------------

    Topology today has some common classes that are often reused throughout
    with slightly altered configurations. i.e. widgets (components),
    pipelines, dais and controls.

    Topology2.0 introduces the high level concept of reusable "class" like
    definition for a AIF_IN/AIF_OUT type object that can be used to create
    topology objects.

    **Common Topology Attributes**
    --------------------------
    Topology defines a lot of attributes per object with different types
    and constraints. Today there is no easy way to validate type or
    constraints and this can lead to many hard to find problems in FW at
    runtime.

    A new keyword "DefineAttribute" has been added to define attribute
    type, size, min value, max value, enum_values. This then allows
    alsatplg to validate each topology object attribute.

    Topology Classes define the list of attributes that they use and
    whether the attribute is mandatory, can be overridden by parent users
    or is immutable. This also helps alsatplg emit the appropriate errors
    for attribute misuse.

    **Common Topology Arguments**
    -------------------------

    Arguments are used to pass essential data needed for instantiating an
    object particularly needed for the object name. A new keyword
    "DefineArgument" has been added to define the arguments. The order in
    which the arguments are defined determines the name for the widget.
    For example, in the case of the host widget, the name would be
    constructed as "host.1.playback" where "1" is the pipeline_id argument
    value and "playback" is the direction argument value.

    **Attribute Inheritance:**
    ----------------------
    One of the key features of Topology2.0 is howthe attribute values are
    propagated from a parent object to a child object. This is accomplished
    by adding attributes/arguments with the same name for a parent and an
    object. By doing so, when creating a child object, the value for the
    common attribute is populated from the parent. If the value is provided
    in the child object instance, then it overrides the value coming from
    the parent.

    **ALSA Conf Parser**
    ----------------

    All the changes being proposed and discussed here must be 100%
    compliant with the ALSA conf parser. i.e. no syntax changes or
    changes to semantics for any existing keyword.

    It's intended that there will be NO changes to the ALSA conf parser
   and all topology building changes will be in the alsatplg compiler.