### PR TITLE
utils/alsa.m4: fix the brackets for real

### DIFF
--- a/utils/alsa.m4
+++ b/utils/alsa.m4
@@ -141,7 +141,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 # error not present
 #endif
 exit(0);
-]],
+]])],
   [AC_MSG_RESULT(yes)
    enable_atopology="yes"],
   [AC_MSG_RESULT(no)]


### PR DESCRIPTION
Even after https://github.com/alsa-project/alsa-lib/commit/f9ace404fde9058baf64d77eed98d755a6c11fa4 building alsa-utils from git fails due to broken alsa.m4.

```
autoreconf: running: aclocal -I m4 --force -I m4
/home/asavah/kross/host/bin/m4:/home/asavah/kross/build/asusb450eg/rootfs/usr/share/aclocal/alsa.m4:20: ERROR: end of file in string
autom4te2.71: error: /home/asavah/kross/host/bin/m4 failed with exit status: 1
aclocal: error: /home/asavah/kross/host/bin/autom4te2.71 failed with exit status: 1
autoreconf: error: aclocal failed with exit status: 1
```

This PR should address missing brackets.