### PR TITLE
topology/pcm.c: remove duplicated AC97 hw format

### DIFF
--- a/src/topology/pcm.c
+++ b/src/topology/pcm.c
@@ -1367,10 +1367,6 @@ static struct audio_hw_format audio_hw_formats[] = {
 		.name = "AC97",
 	},
 	{
-		.type = SND_SOC_DAI_FORMAT_AC97,
-		.name = "AC97",
-	},
-	{
 		.type = SND_SOC_DAI_FORMAT_PDM,
 		.name = "PDM",
 	},


### PR DESCRIPTION
Remove the second occurrence of AC97 hardware format
from audio hardware format array.

Signed-off-by: Chao Song <chao.song@linux.intel.com>