### PR TITLE
ucm_exec.c: Include limits.h explicitly to fix build on musl

### DIFF
--- a/src/ucm/ucm_exec.c
+++ b/src/ucm/ucm_exec.c
@@ -30,6 +30,7 @@
 #include "ucm_local.h"
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <limits.h>
 #include <dirent.h>
 
 static pthread_mutex_t fork_lock = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
Fixes:
| ../../../alsa-lib-1.2.5/src/ucm/ucm_exec.c: In function 'find_exec':
| ../../../alsa-lib-1.2.5/src/ucm/ucm_exec.c:43:18: error: 'PATH_MAX' undeclared (first use in this function)
|    43 |         char bin[PATH_MAX];
|       |                  ^~~~~~~~
| ../../../alsa-lib-1.2.5/src/ucm/ucm_exec.c:43:18: note: each undeclared identifier is reported only once for each function it appears in
| ../../../alsa-lib-1.2.5/src/ucm/ucm_exec.c: In function 'uc_mgr_exec':
| ../../../alsa-lib-1.2.5/src/ucm/ucm_exec.c:177:18: error: 'PATH_MAX' undeclared (first use in this function)
|   177 |         char bin[PATH_MAX];
|       |                  ^~~~~~~~

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>