### PR TITLE
Adjust appl_ptr for multi plugin on rewind/forward operations

### DIFF
--- a/src/pcm/pcm_multi.c
+++ b/src/pcm/pcm_multi.c
@@ -669,6 +669,9 @@ static snd_pcm_sframes_t snd_pcm_multi_rewind(snd_pcm_t *pcm, snd_pcm_uframes_t 
 				return -EIO;
 		}
 	}
+	
+	snd_pcm_mmap_appl_backward(pcm, frames);
+	
 	return frames;
 }
 
@@ -699,6 +702,9 @@ static snd_pcm_sframes_t snd_pcm_multi_forward(snd_pcm_t *pcm, snd_pcm_uframes_t
 				return -EIO;
 		}
 	}
+	
+	snd_pcm_mmap_appl_forward(pcm, frames);
+	
 	return frames;
 }
 
@@ -782,8 +788,9 @@ static snd_pcm_sframes_t snd_pcm_multi_mmap_commit(snd_pcm_t *pcm,
 		if ((snd_pcm_uframes_t)result != size)
 			return -EIO;
 	}
-	multi->appl_ptr += size;
-	multi->appl_ptr %= pcm->boundary;
+	
+	snd_pcm_mmap_appl_forward(pcm, size);
+
 	return size;
 }
 


### PR DESCRIPTION
* When doing rewind or forward operations, application pointer needs to
  be properly adjusted, in the same way when doing commit/write
  operations.
* Introduce helper functions for manipulating the application pointer.