### PR TITLE
Add a note about return values of snd_pcm_state()

### DIFF
--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -1059,6 +1059,10 @@ int snd_pcm_status(snd_pcm_t *pcm, snd_pcm_status_t *status)
  * This is a faster way to obtain only the PCM state without calling
  * \link ::snd_pcm_status() \endlink.
  *
+ * Note that this function always returns one of the
+ * #snd_pcm_state_t enum variants.
+ * It will never return a negative error code.
+ *
  * The function is thread-safe when built with the proper option.
  */
 snd_pcm_state_t snd_pcm_state(snd_pcm_t *pcm)


### PR DESCRIPTION
This is a suggested improvement to the documentation of `snd_pcm_state()`. There is some confusion, probably caused by old bugs that could made it return a negative error code. This stuff is still floating around the internet and sometimes shows up in searches. This PR adds a comment intended to make it absolutely clear that there is never supposed to be a negative error code.