### PR TITLE
Fix alsa-utils building error on NetBSD

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#include <stdarg.h>
+
 /**
  *  \defgroup Error Error handling
  *  Error handling macros and functions.

--- a/include/output.h
+++ b/include/output.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#include <stdarg.h>
+
 /**
  *  \defgroup Output Output Interface
  *


### PR DESCRIPTION
The following errors occur at least on NetBSD 9.2 amd64 when building
alsa-utils:
include/alsa/output.h:75:66: error: unknown type name 'va_list'; did you mean '__va_list'?
include/alsa/error.h:80:25: error: unknown type name 'va_list'; did you mean '__va_list'?