### PR TITLE
rawmidi: hide the frame structure using a decoder function

### DIFF
--- a/include/rawmidi.h
+++ b/include/rawmidi.h
@@ -93,26 +93,6 @@ typedef enum _snd_rawmidi_framing {
 	SND_RAWMIDI_FRAMING_TSTAMP = 1,
 } snd_rawmidi_framing_t;
 
-#define SND_RAWMIDI_FRAME_TYPE_DEFAULT 0
-
-#define SND_RAWMIDI_FRAMING_DATA_LENGTH 16
-
-/** Incoming RawMidi bytes is put inside this container if tstamp type framing is enabled. */
-struct _snd_rawmidi_framing_tstamp {
-	/**
-	 * For now, frame_type is always SND_RAWMIDI_FRAME_TYPE_DEFAULT.
-	 * Midi 2.0 is expected to add new types here.
-	 * Applications are expected to skip unknown frame types.
-	 */
-	uint8_t frame_type;
-	uint8_t length; /* number of valid bytes in data field */
-	uint8_t reserved[2];
-	uint32_t tv_nsec;		/* nanoseconds */
-	uint64_t tv_sec;		/* seconds */
-	uint8_t data[SND_RAWMIDI_FRAMING_DATA_LENGTH];
-} __attribute__((packed));
-typedef struct _snd_rawmidi_framing_tstamp snd_rawmidi_framing_tstamp_t;
-
 int snd_rawmidi_open(snd_rawmidi_t **in_rmidi, snd_rawmidi_t **out_rmidi,
 		     const char *name, int mode);
 int snd_rawmidi_open_lconf(snd_rawmidi_t **in_rmidi, snd_rawmidi_t **out_rmidi,
@@ -184,6 +164,8 @@ int snd_rawmidi_drain(snd_rawmidi_t *rmidi);
 int snd_rawmidi_drop(snd_rawmidi_t *rmidi);
 ssize_t snd_rawmidi_write(snd_rawmidi_t *rmidi, const void *buffer, size_t size);
 ssize_t snd_rawmidi_read(snd_rawmidi_t *rmidi, void *buffer, size_t size);
+ssize_t snd_rawmidi_decode_frame0(snd_rawmidi_t *rmidi, void *buffer, size_t size,
+				  struct timespec *tstamp, void *data, size_t *data_size);
 const char *snd_rawmidi_name(snd_rawmidi_t *rmidi);
 snd_rawmidi_type_t snd_rawmidi_type(snd_rawmidi_t *rmidi);
 snd_rawmidi_stream_t snd_rawmidi_stream(snd_rawmidi_t *rawmidi);


### PR DESCRIPTION
The frame structure should be hidden. Remove it and add
snd_rawmidi_decode_frame0() which returns the timestamp
and the midi chunk pointer to the application.

BugLink: https://github.com/alsa-project/alsa-lib/issues/172
