### PR TITLE
Redesign the rawmidi midi read with timestamping API

### DIFF
--- a/include/rawmidi.h
+++ b/include/rawmidi.h
@@ -93,26 +93,6 @@ typedef enum _snd_rawmidi_framing {
 	SND_RAWMIDI_FRAMING_TSTAMP = 1,
 } snd_rawmidi_framing_t;
 
-#define SND_RAWMIDI_FRAME_TYPE_DEFAULT 0
-
-#define SND_RAWMIDI_FRAMING_DATA_LENGTH 16
-
-/** Incoming RawMidi bytes is put inside this container if tstamp type framing is enabled. */
-struct _snd_rawmidi_framing_tstamp {
-	/**
-	 * For now, frame_type is always SND_RAWMIDI_FRAME_TYPE_DEFAULT.
-	 * Midi 2.0 is expected to add new types here.
-	 * Applications are expected to skip unknown frame types.
-	 */
-	uint8_t frame_type;
-	uint8_t length; /* number of valid bytes in data field */
-	uint8_t reserved[2];
-	uint32_t tv_nsec;		/* nanoseconds */
-	uint64_t tv_sec;		/* seconds */
-	uint8_t data[SND_RAWMIDI_FRAMING_DATA_LENGTH];
-} __attribute__((packed));
-typedef struct _snd_rawmidi_framing_tstamp snd_rawmidi_framing_tstamp_t;
-
 int snd_rawmidi_open(snd_rawmidi_t **in_rmidi, snd_rawmidi_t **out_rmidi,
 		     const char *name, int mode);
 int snd_rawmidi_open_lconf(snd_rawmidi_t **in_rmidi, snd_rawmidi_t **out_rmidi,
@@ -184,6 +164,7 @@ int snd_rawmidi_drain(snd_rawmidi_t *rmidi);
 int snd_rawmidi_drop(snd_rawmidi_t *rmidi);
 ssize_t snd_rawmidi_write(snd_rawmidi_t *rmidi, const void *buffer, size_t size);
 ssize_t snd_rawmidi_read(snd_rawmidi_t *rmidi, void *buffer, size_t size);
+ssize_t snd_rawmidi_tread(snd_rawmidi_t *rmidi, struct timespec *tstamp, void *buffer, size_t size);
 const char *snd_rawmidi_name(snd_rawmidi_t *rmidi);
 snd_rawmidi_type_t snd_rawmidi_type(snd_rawmidi_t *rmidi);
 snd_rawmidi_stream_t snd_rawmidi_stream(snd_rawmidi_t *rawmidi);

--- a/include/rawmidi.h
+++ b/include/rawmidi.h
@@ -79,7 +79,7 @@ typedef enum _snd_rawmidi_type {
 	SND_RAWMIDI_TYPE_VIRTUAL
 } snd_rawmidi_type_t;
 
-/** Type of clock used with rawmidi tstamp framing */
+/** Type of clock used with rawmidi timestamp */
 typedef enum _snd_rawmidi_clock {
 	SND_RAWMIDI_CLOCK_NONE = 0,
 	SND_RAWMIDI_CLOCK_REALTIME = 1,
@@ -87,11 +87,11 @@ typedef enum _snd_rawmidi_clock {
 	SND_RAWMIDI_CLOCK_MONOTONIC_RAW = 3,
 } snd_rawmidi_clock_t;
 
-/** Enable or disable rawmidi framing */
-typedef enum _snd_rawmidi_framing {
-	SND_RAWMIDI_FRAMING_NONE = 0,
-	SND_RAWMIDI_FRAMING_TSTAMP = 1,
-} snd_rawmidi_framing_t;
+/** Select the read mode (standard or with timestamps) */
+typedef enum _snd_rawmidi_read_mode {
+	SND_RAWMIDI_READ_STANDARD = 0,
+	SND_RAWMIDI_READ_TSTAMP = 1,
+} snd_rawmidi_read_mode_t;
 
 int snd_rawmidi_open(snd_rawmidi_t **in_rmidi, snd_rawmidi_t **out_rmidi,
 		     const char *name, int mode);
@@ -140,8 +140,8 @@ int snd_rawmidi_params_set_avail_min(snd_rawmidi_t *rmidi, snd_rawmidi_params_t 
 size_t snd_rawmidi_params_get_avail_min(const snd_rawmidi_params_t *params);
 int snd_rawmidi_params_set_no_active_sensing(snd_rawmidi_t *rmidi, snd_rawmidi_params_t *params, int val);
 int snd_rawmidi_params_get_no_active_sensing(const snd_rawmidi_params_t *params);
-int snd_rawmidi_params_set_framing_type(const snd_rawmidi_t *rawmidi, snd_rawmidi_params_t *params, snd_rawmidi_framing_t val);
-snd_rawmidi_framing_t snd_rawmidi_params_get_framing_type(const snd_rawmidi_params_t *params);
+int snd_rawmidi_params_set_read_mode(const snd_rawmidi_t *rawmidi, snd_rawmidi_params_t *params, snd_rawmidi_read_mode_t val);
+snd_rawmidi_read_mode_t snd_rawmidi_params_get_read_mode(const snd_rawmidi_params_t *params);
 int snd_rawmidi_params_set_clock_type(const snd_rawmidi_t *rawmidi, snd_rawmidi_params_t *params, snd_rawmidi_clock_t val);
 snd_rawmidi_clock_t snd_rawmidi_params_get_clock_type(const snd_rawmidi_params_t *params);
 

--- a/include/sound/uapi/asound.h
+++ b/include/sound/uapi/asound.h
@@ -773,6 +773,7 @@ struct snd_rawmidi_status {
 
 #define SNDRV_RAWMIDI_IOCTL_PVERSION	_IOR('W', 0x00, int)
 #define SNDRV_RAWMIDI_IOCTL_INFO	_IOR('W', 0x01, struct snd_rawmidi_info)
+#define SNDRV_RAWMIDI_IOCTL_USER_PVERSION _IOW('W', 0x02, int)
 #define SNDRV_RAWMIDI_IOCTL_PARAMS	_IOWR('W', 0x10, struct snd_rawmidi_params)
 #define SNDRV_RAWMIDI_IOCTL_STATUS	_IOWR('W', 0x20, struct snd_rawmidi_status)
 #define SNDRV_RAWMIDI_IOCTL_DROP	_IOW('W', 0x30, int)

--- a/src/rawmidi/rawmidi.c
+++ b/src/rawmidi/rawmidi.c
@@ -1071,11 +1071,30 @@ ssize_t snd_rawmidi_write(snd_rawmidi_t *rawmidi, const void *buffer, size_t siz
  * \param rawmidi RawMidi handle
  * \param buffer buffer to store the input MIDI bytes
  * \param size input buffer size in bytes
+ * \retval count of MIDI bytes otherwise a negative error code
  */
 ssize_t snd_rawmidi_read(snd_rawmidi_t *rawmidi, void *buffer, size_t size)
 {
 	assert(rawmidi);
 	assert(rawmidi->stream == SND_RAWMIDI_STREAM_INPUT);
+	if ((rawmidi->params_mode & SNDRV_RAWMIDI_MODE_FRAMING_MASK) == SNDRV_RAWMIDI_MODE_FRAMING_TSTAMP)
+		size &= ~(sizeof(struct snd_rawmidi_framing_tstamp) - 1);
 	assert(buffer || size == 0);
 	return (rawmidi->ops->read)(rawmidi, buffer, size);
+}
+
+/**
+ * \brief read MIDI bytes from MIDI stream with timestamp
+ * \param rawmidi RawMidi handle
+ * \param[out] tstamp timestamp for the returned MIDI bytes
+ * \param buffer buffer to store the input MIDI bytes
+ * \param size input buffer size in bytes
+ * \retval count of MIDI bytes otherwise a negative error code
+ */
+ssize_t snd_rawmidi_tread(snd_rawmidi_t *rawmidi, struct timespec *tstamp, void *buffer, size_t size)
+{
+	assert(rawmidi);
+	assert(rawmidi->stream == SND_RAWMIDI_STREAM_INPUT);
+	assert(buffer || size == 0);
+	return (rawmidi->ops->tread)(rawmidi, tstamp, buffer, size);
 }

--- a/src/rawmidi/rawmidi.c
+++ b/src/rawmidi/rawmidi.c
@@ -118,14 +118,14 @@ hw:soundwave,1,2
 hw:DEV=1,CARD=soundwave,SUBDEV=2
 \endcode
 
-\section rawmidi_framing Framing of rawmidi data
+\section read_mode Read mode
 
-Optionally, incoming rawmidi bytes can be put inside a frame of type snd_rawmidi_framing_tstamp_t.
-The main current benefit is that can enable in-kernel timestamping of incoming bytes, and that
-timestamp is likely to be more precise than what userspace can offer.
+Optionally, incoming rawmidi bytes can be marked with timestamps. The library hides
+the kernel implementation (linux kernel 5.14+) and exports
+the \link ::snd_rawmidi_tread() \endlink  function which returns the
+midi bytes marked with the identical timestamp in one iteration.
 
-Tstamp type framing requires a kernel >= 5.14 and a buffer size that is a multiple of
-sizeof(snd_rawmidi_framing_tstamp_t). It is only available on input streams.
+The timestamping is available only on input streams.
 
 \section rawmidi_examples Examples
 

--- a/src/rawmidi/rawmidi.c
+++ b/src/rawmidi/rawmidi.c
@@ -1112,5 +1112,7 @@ ssize_t snd_rawmidi_tread(snd_rawmidi_t *rawmidi, struct timespec *tstamp, void 
 	assert(rawmidi);
 	assert(rawmidi->stream == SND_RAWMIDI_STREAM_INPUT);
 	assert(buffer || size == 0);
+	if ((rawmidi->params_mode & SNDRV_RAWMIDI_MODE_FRAMING_MASK) == SNDRV_RAWMIDI_MODE_FRAMING_TSTAMP)
+		return -EINVAL;
 	return (rawmidi->ops->tread)(rawmidi, tstamp, buffer, size);
 }

--- a/src/rawmidi/rawmidi.c
+++ b/src/rawmidi/rawmidi.c
@@ -844,6 +844,8 @@ int snd_rawmidi_params_set_read_mode(const snd_rawmidi_t *rawmidi, snd_rawmidi_p
 		framing = SNDRV_RAWMIDI_MODE_FRAMING_NONE;
 		break;
 	case SND_RAWMIDI_READ_TSTAMP:
+		if (rawmidi->ops->tread == NULL)
+			return -ENOTSUP;
 		framing = SNDRV_RAWMIDI_MODE_FRAMING_TSTAMP;
 		break;
 	default:
@@ -1114,5 +1116,7 @@ ssize_t snd_rawmidi_tread(snd_rawmidi_t *rawmidi, struct timespec *tstamp, void 
 	assert(buffer || size == 0);
 	if ((rawmidi->params_mode & SNDRV_RAWMIDI_MODE_FRAMING_MASK) == SNDRV_RAWMIDI_MODE_FRAMING_TSTAMP)
 		return -EINVAL;
+	if (rawmidi->ops->tread == NULL)
+		return -ENOTSUP;
 	return (rawmidi->ops->tread)(rawmidi, tstamp, buffer, size);
 }

--- a/src/rawmidi/rawmidi_hw.c
+++ b/src/rawmidi/rawmidi_hw.c
@@ -354,6 +354,11 @@ int snd_rawmidi_hw_open(snd_rawmidi_t **inputp, snd_rawmidi_t **outputp,
 		snd_ctl_close(ctl);
 		return -SND_ERROR_INCOMPATIBLE_VERSION;
 	}
+	if (SNDRV_PROTOCOL_VERSION(2, 0, 2) <= ver) {
+		/* inform the protocol version we're supporting */
+		unsigned int user_ver = SNDRV_RAWMIDI_VERSION;
+		ioctl(fd, SNDRV_RAWMIDI_IOCTL_USER_PVERSION, &user_ver);
+	}
 	if (subdevice >= 0) {
 		memset(&info, 0, sizeof(info));
 		info.stream = outputp ? SNDRV_RAWMIDI_STREAM_OUTPUT : SNDRV_RAWMIDI_STREAM_INPUT;

--- a/src/rawmidi/rawmidi_hw.c
+++ b/src/rawmidi/rawmidi_hw.c
@@ -114,6 +114,12 @@ static int snd_rawmidi_hw_params(snd_rawmidi_t *rmidi, snd_rawmidi_params_t * pa
 		return -errno;
 	}
 	buf_reset(hw);
+	if (hw->buf &&
+	    ((params->mode & SNDRV_RAWMIDI_MODE_FRAMING_MASK) != SNDRV_RAWMIDI_MODE_FRAMING_TSTAMP)) {
+		free(hw->buf);
+		hw->buf = NULL;
+		hw->buf_size = 0;
+	}
 	return 0;
 }
 

--- a/src/rawmidi/rawmidi_local.h
+++ b/src/rawmidi/rawmidi_local.h
@@ -34,6 +34,7 @@ typedef struct {
 	int (*drain)(snd_rawmidi_t *rawmidi);
 	ssize_t (*write)(snd_rawmidi_t *rawmidi, const void *buffer, size_t size);
 	ssize_t (*read)(snd_rawmidi_t *rawmidi, void *buffer, size_t size);
+	ssize_t (*tread)(snd_rawmidi_t *rawmidi, struct timespec *tstamp, void *buffer, size_t size);
 } snd_rawmidi_ops_t;
 
 struct _snd_rawmidi {

--- a/test/rawmidi.c
+++ b/test/rawmidi.c
@@ -151,9 +151,9 @@ int main(int argc,char** argv)
 				if (clock_type != -1) {
 					fprintf(stderr, "Enable kernel clock type %d\n", clock_type);
 					snd_rawmidi_params_current(handle_in, params);
-					err = snd_rawmidi_params_set_framing_type(handle_in, params, 1);
+					err = snd_rawmidi_params_set_read_mode(handle_in, params, SND_RAWMIDI_READ_TSTAMP);
 					if (err) {
-						fprintf(stderr,"snd_rawmidi_params_set_framing_type failed: %d\n", err);
+						fprintf(stderr,"snd_rawmidi_params_set_read_mode failed: %d\n", err);
 						clock_type = -1;
 					}
 				}


### PR DESCRIPTION
It's follow-up for https://github.com/alsa-project/alsa-lib/pull/173 and https://github.com/alsa-project/alsa-lib/issues/172 . 

I am confident, that the direct framing mechanism for the transfer of the midi stream with the timestamping should be hidden and abstracted in the alsa-lib's API. This version uses a new read function (`snd_rawmidi_tread()`) which decodes and merges the data from the kernel frames. The framing mechanism is very specific to the kernel API and the cost of added data copy is negligible in this case (the kernel code basically does similar thing).

I kept the `snd_rawmidi_read()` functionality to read raw frames), but the structure for the parsing must be defined on it's own. This mechanism is unsupported.

This version seems more abstract and easy to use for apps than the separate decoder function for `snd_rawmidi_read()`.
