### PR TITLE
dlmisc.c: Avoid double unlock in snd_dlobj_cache_get0()

### DIFF
--- a/src/dlmisc.c
+++ b/src/dlmisc.c
@@ -359,7 +359,6 @@ snd_dlobj_cache_get0(const char *lib, const char *name,
 		free(c);
 	      __err:
 		snd_dlclose(dlobj);
-		snd_dlobj_unlock();
 		return NULL;
 	}
 	c->dlobj = dlobj;


### PR DESCRIPTION
Remove call to snd_dlobj_unlock() in snd_dlobj_cache_get0()
All lock/unlock is done by callers of the function.

Fixes: https://github.com/alsa-project/alsa-lib/issues/181