### PR TITLE
src/topology/parser.c: drop duplicate safe_strtol_base

### DIFF
--- a/src/topology/parser.c
+++ b/src/topology/parser.c
@@ -22,25 +22,6 @@
 #include "tplg_local.h"
 
 /*
- * Safe strtol call
- */
-int safe_strtol_base(const char *str, long *val, int base)
-{
-	char *end;
-	long v;
-	if (!*str)
-		return -EINVAL;
-	errno = 0;
-	v = strtol(str, &end, base);
-	if (errno)
-		return -errno;
-	if (*end)
-		return -EINVAL;
-	*val = v;
-	return 0;
-}
-
-/*
  * Get integer value
  */
 int tplg_get_integer(snd_config_t *n, int *val, int base)


### PR DESCRIPTION
`safe_strtol_base` is defined twice since https://github.com/alsa-project/alsa-lib/commit/f547b2e35f71e89397e8b29cd0b9083bb68b00a6 and https://github.com/alsa-project/alsa-lib/commit/5fab157a593180525607b7d26263bee127f6be36 resulting in the following build failure when alsa-utils is built statically:

```
checking for snd_tplg_new in -latopology... no
configure: error: No linkable libatopology was found.
```

because `safe_strtol_base` is defined twice:

```
configure:7776: checking for snd_tplg_new in -latopology
configure:7801: /home/buildroot/autobuild/instance-2/output-1/host/bin/arm-linux-gcc -o conftest -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os -g0  -static -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -static conftest.c -latopology  -lasound  -lasound -lm  -lpthread  >&5
/home/buildroot/autobuild/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: /home/buildroot/autobuild/instance-2/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libasound.a(conf.o): in function `safe_strtol_base':
conf.c:(.text+0x1600): multiple definition of `safe_strtol_base'; /home/buildroot/autobuild/instance-2/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libatopology.a(parser.o):parser.c:(.text+0x130): first defined here

```

Fixes:
 - http://autobuild.buildroot.org/results/08d028004090b2a8292f03910cb9bf80a73ac804

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>