### PR TITLE
src/topology/parser.c: drop duplicate safe_strtol_base

### DIFF
--- a/src/topology/data.c
+++ b/src/topology/data.c
@@ -414,7 +414,7 @@ static int write_hex(char *buf, char *str, int width)
 	void *p = &val;
 
         errno = 0;
-	if (safe_strtol_base(str, &val, 16) < 0)
+	if (tplg_safe_strtol_base(str, &val, 16) < 0)
 		return -EINVAL;
 
 	switch (width) {

--- a/src/topology/ops.c
+++ b/src/topology/ops.c
@@ -43,7 +43,7 @@ static int lookup_ops(const char *c)
 	}
 
 	/* cant find string name in our table so we use its ID number */
-	i = safe_strtol(c, &ret);
+	i = tplg_safe_strtol(c, &ret);
 	if (i < 0) {
 		SNDERR("wrong kcontrol ops value string '%s'", c);
 		return i;

--- a/src/topology/parser.c
+++ b/src/topology/parser.c
@@ -22,6 +22,25 @@
 #include "tplg_local.h"
 
 /*
+ * Safe strtol call
+ */
+int safe_strtol_base(const char *str, long *val, int base)
+{
+	char *end;
+	long v;
+	if (!*str)
+		return -EINVAL;
+	errno = 0;
+	v = strtol(str, &end, base);
+	if (errno)
+		return -errno;
+	if (*end)
+		return -EINVAL;
+	*val = v;
+	return 0;
+}
+
+/*
  * Get integer value
  */
 int tplg_get_integer(snd_config_t *n, int *val, int base)

--- a/src/topology/parser.c
+++ b/src/topology/parser.c
@@ -24,7 +24,7 @@
 /*
  * Safe strtol call
  */
-int safe_strtol_base(const char *str, long *val, int base)
+int tplg_safe_strtol_base(const char *str, long *val, int base)
 {
 	char *end;
 	long v;
@@ -59,7 +59,7 @@ int tplg_get_integer(snd_config_t *n, int *val, int base)
 		err = snd_config_get_string(n, &str);
 		if (err < 0)
 			return err;
-		err = safe_strtol_base(str, &lval, base);
+		err = tplg_safe_strtol_base(str, &lval, base);
 		if (err < 0)
 			return err;
 		goto __retval;

--- a/src/topology/tplg_local.h
+++ b/src/topology/tplg_local.h
@@ -407,6 +407,9 @@ int tplg_save_stream_caps(snd_tplg_t *tplg, struct tplg_elem *elem,
 int tplg_save_dai(snd_tplg_t *tplg, struct tplg_elem *elem,
 		  struct tplg_buf *dst, const char *pfx);
 
+int tplg_safe_strtol_base(const char *str, long *val, int base);
+static inline int tplg_safe_strtol(const char *str, long *val) { return tplg_safe_strtol_base(str, val, 0); }
+
 int tplg_decode_template(snd_tplg_t *tplg,
 			 size_t pos,
 			 struct snd_soc_tplg_hdr *hdr,


### PR DESCRIPTION
`safe_strtol_base` is defined twice since https://github.com/alsa-project/alsa-lib/commit/f547b2e35f71e89397e8b29cd0b9083bb68b00a6 and https://github.com/alsa-project/alsa-lib/commit/5fab157a593180525607b7d26263bee127f6be36 resulting in the following build failure when alsa-utils is built statically:

```
checking for snd_tplg_new in -latopology... no
configure: error: No linkable libatopology was found.

```
because `safe_strtol_base` is defined twice:

```
configure:7776: checking for snd_tplg_new in -latopology
configure:7801: /home/buildroot/autobuild/instance-2/output-1/host/bin/arm-linux-gcc -o conftest -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os -g0  -static -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -static conftest.c -latopology  -lasound  -lasound -lm  -lpthread  >&5
/home/buildroot/autobuild/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: /home/buildroot/autobuild/instance-2/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libasound.a(conf.o): in function `safe_strtol_base':
conf.c:(.text+0x1600): multiple definition of `safe_strtol_base'; /home/buildroot/autobuild/instance-2/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libatopology.a(parser.o):parser.c:(.text+0x130): first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/08d028004090b2a8292f03910cb9bf80a73ac804