### PR TITLE
pcm: dmix: fix wrong scaling in 32bits pcm mixing

### DIFF
--- a/src/pcm/pcm_dmix_generic.c
+++ b/src/pcm/pcm_dmix_generic.c
@@ -330,7 +330,7 @@ static void generic_mix_areas_32_swap(unsigned int size,
 	register signed int sample;
 
 	for (;;) {
-		sample = bswap_32(*src) >> 8;
+		sample = (signed int) bswap_32(*src) >> 8;
 		if (! *dst) {
 			*sum = sample;
 			*dst = *src;
@@ -364,7 +364,7 @@ static void generic_remix_areas_32_swap(unsigned int size,
 	register signed int sample;
 
 	for (;;) {
-		sample = bswap_32(*src) >> 8;
+		sample = (signed int) bswap_32(*src) >> 8;
 		if (! *dst) {
 			*sum = -sample;
 			*dst = bswap_32(-sample);


### PR DESCRIPTION
Generic mixing function for 32bits pcm has used 8bits right shift for
pre-scaling. But this is generating wrong result if pcm data is
negative value because return value type of bswap_32() is unsigned int.

This patch adds type cast bswap_32() result to signed int.