### PR TITLE
chore: Unify Travis CI process to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,7 @@ jobs:
     - name: Install
       run: |
         make install
+
+  gitcompile:
+    run: sed 's/-Wunused-const-variable=0//g' < gitcompile > gitcompile.sh
+    run: bash gitcompile.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .*
-!.travis.yml
 configure
 config.log
 config.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: required
-language: c
-script:
-  - sed 's/-Wunused-const-variable=0//g' < gitcompile > gitcompile.travis
-  - bash gitcompile.travis


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).