### PR TITLE
Add missing implementation for topology ignore_suspend flag

### DIFF
--- a/src/topology/dapm.c
+++ b/src/topology/dapm.c
@@ -605,6 +605,17 @@ int tplg_parse_dapm_widget(snd_tplg_t *tplg,
 			continue;
 		}
 
+		if (strcmp(id, "ignore_suspend") == 0) {
+			ival = snd_config_get_bool(n);
+			if (ival < 0)
+				return -EINVAL;
+
+			widget->ignore_suspend = ival;
+
+			tplg_dbg("\t%s: %s", id, val);
+			continue;
+		}
+
 		if (strcmp(id, "subseq") == 0) {
 			if (tplg_get_integer(n, &ival, 0))
 				return -EINVAL;
@@ -700,6 +711,9 @@ int tplg_save_dapm_widget(snd_tplg_t *tplg ATTRIBUTE_UNUSED,
 	if (err >= 0 && widget->invert)
 		err = tplg_save_printf(dst, pfx, "\tinvert %u\n",
 				       widget->invert);
+	if (err >= 0 && widget->ignore_suspend)
+		err = tplg_save_printf(dst, pfx, "\tignore_suspend %u\n",
+				       widget->ignore_suspend);
 	if (err >= 0 && widget->subseq)
 		err = tplg_save_printf(dst, pfx, "\tsubseq %u\n",
 				       widget->subseq);

--- a/src/topology/pcm.c
+++ b/src/topology/pcm.c
@@ -812,15 +812,17 @@ static int parse_flag(snd_config_t *n, unsigned int mask_in,
 static int save_flags(unsigned int flags, unsigned int mask,
 		      struct tplg_buf *dst, const char *pfx)
 {
-	static unsigned int flag_masks[3] = {
+	static unsigned int flag_masks[4] = {
 		SND_SOC_TPLG_LNK_FLGBIT_SYMMETRIC_RATES,
 		SND_SOC_TPLG_LNK_FLGBIT_SYMMETRIC_CHANNELS,
 		SND_SOC_TPLG_LNK_FLGBIT_SYMMETRIC_SAMPLEBITS,
+		SND_SOC_TPLG_LNK_FLGBIT_VOICE_WAKEUP,
 	};
-	static const char *flag_ids[3] = {
+	static const char *flag_ids[4] = {
 		"symmetric_rates",
 		"symmetric_channels",
 		"symmetric_sample_bits",
+		"ignore_suspend",
 	};
 	unsigned int i;
 	int err = 0;

--- a/src/topology/pcm.c
+++ b/src/topology/pcm.c
@@ -929,6 +929,15 @@ int tplg_parse_pcm(snd_tplg_t *tplg, snd_config_t *cfg,
 			continue;
 		}
 
+		if (strcmp(id, "ignore_suspend") == 0) {
+			err = parse_flag(n,
+				SND_SOC_TPLG_LNK_FLGBIT_VOICE_WAKEUP,
+				&pcm->flag_mask, &pcm->flags);
+			if (err < 0)
+				return err;
+			continue;
+		}
+
 		/* private data */
 		if (strcmp(id, "data") == 0) {
 			err = tplg_parse_refs(n, elem, SND_TPLG_TYPE_DATA);
@@ -1060,6 +1069,15 @@ int tplg_parse_dai(snd_tplg_t *tplg, snd_config_t *cfg,
 		if (strcmp(id, "symmetric_sample_bits") == 0) {
 			err = parse_flag(n,
 				SND_SOC_TPLG_DAI_FLGBIT_SYMMETRIC_SAMPLEBITS,
+				&dai->flag_mask, &dai->flags);
+			if (err < 0)
+				return err;
+			continue;
+		}
+
+		if (strcmp(id, "ignore_suspend") == 0) {
+			err = parse_flag(n,
+				SND_SOC_TPLG_LNK_FLGBIT_VOICE_WAKEUP,
 				&dai->flag_mask, &dai->flags);
 			if (err < 0)
 				return err;
@@ -1214,6 +1232,15 @@ int tplg_parse_link(snd_tplg_t *tplg, snd_config_t *cfg,
 		if (strcmp(id, "symmetric_sample_bits") == 0) {
 			err = parse_flag(n,
 				SND_SOC_TPLG_LNK_FLGBIT_SYMMETRIC_SAMPLEBITS,
+				&link->flag_mask, &link->flags);
+			if (err < 0)
+				return err;
+			continue;
+		}
+
+		if (strcmp(id, "ignore_suspend") == 0) {
+			err = parse_flag(n,
+				SND_SOC_TPLG_LNK_FLGBIT_VOICE_WAKEUP,
 				&link->flag_mask, &link->flags);
 			if (err < 0)
 				return err;


### PR DESCRIPTION
ignore_suspend flag was ignored while parsing topology, add missing support for it. This allows use of it on DAI links and DAPM widgets.