### PR TITLE
conf: Use ino64_t to save and compare inode numbers

### DIFF
--- a/include/local.h
+++ b/include/local.h
@@ -84,6 +84,7 @@
 #define scandir64 scandir
 #define versionsort64 versionsort
 #define alphasort64 alphasort
+#define ino64_t ino_t
 #endif
 
 #define _snd_config_iterator list_head

--- a/src/conf.c
+++ b/src/conf.c
@@ -3921,7 +3921,7 @@ snd_config_t *snd_config = NULL;
 struct finfo {
 	char *name;
 	dev_t dev;
-	ino_t ino;
+	ino64_t ino;
 	time_t mtime;
 };
 


### PR DESCRIPTION
On 32-bit platforms when not using the large-file-support ABI,
struct stat64 contains ino64_t which is 64-bit, while ino_t is only
32-bit.

snd_config_update_r() checks whether a file has been replaced by saving
the ino member of a struct stat64 and comparing it with a previously-saved
inode number. On 32-bit platforms, assigning the 64-bit member of struct
stat64 to a 32-bit member of struct finfo will truncate it modulo 1<<32,
which could conceivably result in libasound not reloading configuration
when it should (although the inode number space is large enough to make
this failure mode highly unlikely).

---

This is from source code inspection while looking at #223, I haven't seen a genuine user-observable bug result from this.

cc @dos1, @perexg, @bertogg