### PR TITLE
control: Fall back to old naming if ELD device name decoding fails

### DIFF
--- a/src/control/control_hw.c
+++ b/src/control/control_hw.c
@@ -288,8 +288,10 @@ static int snd_ctl_hw_pcm_info(snd_ctl_t *handle, snd_pcm_info_t * info)
 	if (ioctl(hw->fd, SNDRV_CTL_IOCTL_PCM_INFO, info) < 0)
 		return -errno;
 	/* may be configurable (optional) */
-	if (__snd_pcm_info_eld_fixup_check(info))
-		return __snd_pcm_info_eld_fixup(info);
+	if (__snd_pcm_info_eld_fixup_check(info)) {
+		if (__snd_pcm_info_eld_fixup(info))
+			SYSMSG("ELD lookup failed, using old HDMI output names\n");
+	}
 	return 0;
 }
 

--- a/src/pcm/pcm_hw.c
+++ b/src/pcm/pcm_hw.c
@@ -325,7 +325,8 @@ static int snd_pcm_hw_info(snd_pcm_t *pcm, snd_pcm_info_t * info)
 	}
 	/* may be configurable (optional) */
 	if (__snd_pcm_info_eld_fixup_check(info))
-		return __snd_pcm_info_eld_fixup(info);
+		if (__snd_pcm_info_eld_fixup(info))
+			SYSMSG("ELD lookup failed, using old HDMI output names\n");
 	return 0;
 }
 


### PR DESCRIPTION
If ELD device name lookup fails, fall back to the old style naming
instead of disabling the HDMI output altogether.

Fixes: https://github.com/alsa-project/alsa-lib/issues/233
Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>