### PR TITLE
output: include stdarg.h

### DIFF
--- a/include/output.h
+++ b/include/output.h
@@ -28,6 +28,8 @@
 #ifndef __ALSA_OUTPUT_H
 #define __ALSA_OUTPUT_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fixes a build error with alsa-utils when build with a uClibc toolchain:

alsa-utils/host/x86_64-buildroot-linux-uclibc/sysroot/usr/include/alsa/output.h:75:66:
 error: unknown type name ‘va_list’
   75 | int snd_output_vprintf(snd_output_t *output, const char *format, va_list args);
      |                                                                  ^~~~~~~
alsa-utils/host/x86_64-buildroot-linux-uclibc/sysroot/usr/include/alsa/output.h:1:1:
 note: ‘va_list’ is defined in header ‘<stdarg.h>’; did you forget to ‘#include <stdarg.h>’?