### PR TITLE
pcm: Add error handler for `fgets`

### DIFF
--- a/src/pcm/pcm_dmix_i386.c
+++ b/src/pcm/pcm_dmix_i386.c
@@ -104,8 +104,7 @@ static void mix_select_callbacks(snd_pcm_direct_t *dmix)
 		/* try to determine the capabilities of the CPU */
 		in = fopen("/proc/cpuinfo", "r");
 		if (in) {
-			while (!feof(in)) {
-				fgets(line, sizeof(line), in);
+			while (!feof(in) && (fgets(line, sizeof(line), in) != NULL)) {
 				if (!strncmp(line, "processor", 9))
 					smp++;
 				else if (!strncmp(line, "flags", 5)) {

--- a/src/pcm/pcm_dmix_x86_64.c
+++ b/src/pcm/pcm_dmix_x86_64.c
@@ -87,8 +87,7 @@ static void mix_select_callbacks(snd_pcm_direct_t *dmix)
 		/* try to determine, if we have SMP */
 		in = fopen("/proc/cpuinfo", "r");
 		if (in) {
-			while (!feof(in)) {
-				fgets(line, sizeof(line), in);
+			while (!feof(in) && (fgets(line, sizeof(line), in) != NULL)) {
 				if (!strncmp(line, "processor", 9))
 					smp++;
 			}


### PR DESCRIPTION
`fgets` function returns `NULL` if error occured. Therefore, end loop in the case.