### PR TITLE
include/sound/type_compat.h: fix include guard

### DIFF
--- a/include/sound/type_compat.h
+++ b/include/sound/type_compat.h
@@ -1,5 +1,5 @@
-#ifndef __TYPE_COMPAT_H
-#define __TYPE_COMPAT_H
+#ifndef __SOUND_TYPE_COMPAT_H
+#define __SOUND_TYPE_COMPAT_H
 
 #ifndef DOC_HIDDEN
 #include <stdint.h>
@@ -58,4 +58,4 @@ typedef int64_t __s64;
 
 #endif /* DOC_HIDDEN */
 
-#endif /* __TYPE_COMPAT_H */
+#endif /* __SOUND_TYPE_COMPAT_H */


### PR DESCRIPTION
include/sound/type_compat.h uses `#define __TYPE_COMPAT_H` but it conflicts
same include guard of include/type_compat.h

now, include/sound/type_compat.h uses `#define __SOUND_TYPE_COMPAT_H`

this is already done in NetBSD's pkgsrc patch.

(thanks to tsutsui@netbsd.org)