### PR TITLE
ucm: fix st_mode check for symbolic links

### DIFF
--- a/src/ucm/parser.c
+++ b/src/ucm/parser.c
@@ -2630,7 +2630,7 @@ static int parse_toplevel_path(snd_use_case_mgr_t *uc_mgr,
 
 		ucm_filename(fn, sizeof(fn), version, dir, file);
 		if (access(fn, R_OK) == 0 && lstat64(fn, &st) == 0) {
-			if (st.st_mode & S_IFLNK) {
+			if (S_ISLNK(st.st_mode)) {
 				ssize_t r;
 				char *link, *dir2, *p;
 


### PR DESCRIPTION
The file type in the st_mode field is not encoded as unique bits but as
an enumerator. Checking if some bits of S_IFLNK are set does not work
correctly because it happens to evaluate to true for regular files as
well.

The POSIX man page suggests using the following approach to check
the file type:

    if ((sb.st_mode & S_IFMT) == S_IFLNK)

Alternatively, there is a S_ISLNK() macro to check this more easily.

Make use of the latter so that readlink() is only called on actual
symbolic links and not regular files. This makes audio work again
with slightly older alsa-ucm-conf versions or alternative top-level
configurations that do not make use of symlinks.

Fixes: d6adde0e ("ucm: top-level path - set directory from symlink")
Signed-off-by: Stephan Gerhold <stephan@gerhold.net>