### PR TITLE
NetBSD/OpenBSD/FreeBSD build support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -335,7 +335,7 @@ else
 fi
 
 dnl Check for headers
-AC_CHECK_HEADERS([endian.h sys/endian.h sys/shm.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h sys/shm.h malloc.h])
 
 dnl Check for resmgr support...
 AC_MSG_CHECKING(for resmgr support)

--- a/configure.ac
+++ b/configure.ac
@@ -764,8 +764,9 @@ AC_OUTPUT(Makefile doc/Makefile doc/pictures/Makefile doc/doxygen.cfg \
 dnl Create asoundlib.h dynamically according to configure options
 echo "Creating asoundlib.h..."
 cp "$srcdir"/include/asoundlib-head.h include/asoundlib.h
+if test "$ac_cv_header_sys_endian_h" != "yes"; then
 test "$ac_cv_header_endian_h" = "yes" && echo "#include <endian.h>" >> include/asoundlib.h
-if test "$ac_cv_header_sys_endian_h" = "yes"; then
+else
 cat >> include/asoundlib.h <<EOF
 #include <sys/endian.h>
 #ifndef __BYTE_ORDER

--- a/include/bswap.h
+++ b/include/bswap.h
@@ -27,6 +27,11 @@
 #define bswap_16 bswap16
 #define bswap_32 bswap32
 #define bswap_64 bswap64
+#elif defined(__OpenBSD__)
+#include <sys/endian.h>
+#define bswap_16 swap16
+#define bswap_32 swap32
+#define bswap_64 swap64
 #elif defined (__sun)
 #include <sys/byteorder.h>
 #define bswap_16 BSWAP_16

--- a/include/local.h
+++ b/include/local.h
@@ -34,6 +34,9 @@
 #include <endian.h>
 #elif defined(HAVE_SYS_ENDIAN_H)
 #include <sys/endian.h>
+#else
+#error Header defining endianness not defined
+#endif
 #ifndef __BYTE_ORDER
 #define __BYTE_ORDER BYTE_ORDER
 #endif
@@ -42,9 +45,6 @@
 #endif
 #ifndef __BIG_ENDIAN
 #define __BIG_ENDIAN BIG_ENDIAN
-#endif
-#else
-#error Header defining endianness not defined
 #endif
 #include <stdarg.h>
 #include <poll.h>
@@ -85,6 +85,8 @@
 #define versionsort64 versionsort
 #define alphasort64 alphasort
 #define ino64_t ino_t
+#define fstat64 fstat
+#define stat64 stat
 #endif
 
 #define _snd_config_iterator list_head

--- a/include/sound/type_compat.h
+++ b/include/sound/type_compat.h
@@ -1,5 +1,5 @@
-#ifndef __TYPE_COMPAT_H
-#define __TYPE_COMPAT_H
+#ifndef __SOUND_TYPE_COMPAT_H
+#define __SOUND_TYPE_COMPAT_H
 
 #ifndef DOC_HIDDEN
 #include <stdint.h>
@@ -58,4 +58,4 @@ typedef int64_t __s64;
 
 #endif /* DOC_HIDDEN */
 
-#endif /* __TYPE_COMPAT_H */
+#endif /* __SOUND_TYPE_COMPAT_H */

--- a/include/sound/type_compat.h
+++ b/include/sound/type_compat.h
@@ -3,7 +3,7 @@
 
 #ifndef DOC_HIDDEN
 #include <stdint.h>
-#ifdef __linux__
+#if defined(__linux__)
 #include <linux/types.h>
 #else
 typedef uint8_t __u8;
@@ -15,8 +15,14 @@ typedef int16_t __s16;
 typedef int32_t __s32;
 typedef int64_t __s64;
 
+#if defined(__sun)
+#include <sys/byteorder.h>
+#define __cpu_to_le32 LE_32(x)
+#define __cpu_to_be32 BE_32(x)
+#define __cpu_to_le16 LE_16(x)
+#define __cpu_to_be16 BE_16(x)
+#else
 #include <endian.h>
-#include <byteswap.h>
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define __cpu_to_le32(x) (x)
 #define __cpu_to_be32(x) bswap_32(x)
@@ -28,20 +34,12 @@ typedef int64_t __s64;
 #define __cpu_to_le16(x) bswap_16(x)
 #define __cpu_to_be16(x) (x)
 #endif
+#endif
 
 #define __le32_to_cpu __cpu_to_le32
 #define __be32_to_cpu __cpu_to_be32
 #define __le16_to_cpu __cpu_to_le16
 #define __be16_to_cpu __cpu_to_be16
-
-#define __le64 __u64
-#define __le32 __u32
-#define __le16 __u16
-#define __le8  __u8
-#define __be64 __u64
-#define __be32 __u32
-#define __be16 __u16
-#define __be8  __u8
 #endif
 
 #ifndef __kernel_long_t

--- a/include/sound/type_compat.h
+++ b/include/sound/type_compat.h
@@ -22,7 +22,7 @@ typedef int64_t __s64;
 #define __cpu_to_le16 LE_16(x)
 #define __cpu_to_be16 BE_16(x)
 #else
-#include <endian.h>
+#include <sys/endian.h>
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define __cpu_to_le32(x) (x)
 #define __cpu_to_be32(x) bswap_32(x)

--- a/include/sound/uapi/asoc.h
+++ b/include/sound/uapi/asoc.h
@@ -16,7 +16,9 @@
 #ifndef __LINUX_UAPI_SND_ASOC_H
 #define __LINUX_UAPI_SND_ASOC_H
 
+#if defined(__linux__)
 #include <linux/types.h>
+#endif
 
 /*
  * Maximum number of channels topology kcontrol can represent.

--- a/include/sound/uapi/asound.h
+++ b/include/sound/uapi/asound.h
@@ -28,7 +28,7 @@
 #include <linux/types.h>
 #include <asm/byteorder.h>
 #else
-#include <endian.h>
+#include <sys/endian.h>
 #include <sys/ioctl.h>
 #endif
 

--- a/src/async.c
+++ b/src/async.c
@@ -54,6 +54,15 @@ static LIST_HEAD(snd_async_handlers);
 
 static void snd_async_handler(int signo ATTRIBUTE_UNUSED, siginfo_t *siginfo, void *context ATTRIBUTE_UNUSED)
 {
+#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+	/* siginfo_t does not have si_fd */
+	struct list_head *i;
+	list_for_each(i, &snd_async_handlers) {
+		snd_async_handler_t *h = list_entry(i, snd_async_handler_t, glist);
+		if (h->callback)
+			h->callback(h);
+	}
+#else
 	int fd;
 	struct list_head *i;
 	//assert(siginfo->si_code == SI_SIGIO);
@@ -66,6 +75,7 @@ static void snd_async_handler(int signo ATTRIBUTE_UNUSED, siginfo_t *siginfo, vo
 		if (h->fd == fd && h->callback)
 			h->callback(h);
 	}
+#endif
 }
 
 /**

--- a/src/conf.c
+++ b/src/conf.c
@@ -4115,7 +4115,7 @@ static int config_file_load(snd_config_t *root, const char *fn, int errors)
 	if (!S_ISDIR(st.st_mode))
 		return config_file_open(root, fn);
 #ifndef DOC_HIDDEN
-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__sun) && !defined(ANDROID)
+#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__sun) && !defined(ANDROID)
 #define SORTFUNC	versionsort64
 #else
 #define SORTFUNC	alphasort64

--- a/src/conf.c
+++ b/src/conf.c
@@ -4115,7 +4115,7 @@ static int config_file_load(snd_config_t *root, const char *fn, int errors)
 	if (!S_ISDIR(st.st_mode))
 		return config_file_open(root, fn);
 #ifndef DOC_HIDDEN
-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(ANDROID)
+#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__sun) && !defined(ANDROID)
 #define SORTFUNC	versionsort64
 #else
 #define SORTFUNC	alphasort64

--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -660,7 +660,9 @@ playback devices.
 
 #include <stdio.h>
 #include <string.h>
+#if HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <stdarg.h>
 #include <signal.h>
 #include <ctype.h>

--- a/src/pcm/pcm_direct.c
+++ b/src/pcm/pcm_direct.c
@@ -44,7 +44,7 @@
  *
  */
  
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__DragonFly__)
 union semun {
 	int              val;    /* Value for SETVAL */
 	struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */

--- a/src/pcm/pcm_direct.c
+++ b/src/pcm/pcm_direct.c
@@ -44,12 +44,16 @@
  *
  */
  
+#if !defined(__OpenBSD__)
 union semun {
 	int              val;    /* Value for SETVAL */
 	struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */
 	unsigned short  *array;  /* Array for GETALL, SETALL */
+#if defined(__linux__)
 	struct seminfo  *__buf;  /* Buffer for IPC_INFO (Linux specific) */
+#endif
 };
+#endif
  
 /*
  * FIXME:

--- a/src/pcm/pcm_mmap.c
+++ b/src/pcm/pcm_mmap.c
@@ -20,7 +20,9 @@
 
 #include "config.h"
 #include <stdio.h>
+#if HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <poll.h>
 #include <sys/mman.h>

--- a/src/seq/seq_midi_event.c
+++ b/src/seq/seq_midi_event.c
@@ -28,7 +28,9 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#if HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include "local.h"
 
 #ifndef DOC_HIDDEN

--- a/src/shmarea.c
+++ b/src/shmarea.c
@@ -24,7 +24,10 @@
 #ifdef HAVE_SYS_SHM_H
 
 #include <stdio.h>
+#include <stdlib.h>
+#if HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <errno.h>
 #include <poll.h>

--- a/src/ucm/parser.c
+++ b/src/ucm/parser.c
@@ -2907,7 +2907,7 @@ int uc_mgr_scan_master_configs(const char **_list[])
 		snprintf(filename, sizeof(filename), "%s/ucm2/conf.virt.d",
 			 snd_config_topdir());
 
-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(ANDROID)
+#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__sun) && !defined(ANDROID)
 #define SORTFUNC	versionsort64
 #else
 #define SORTFUNC	alphasort64

--- a/src/ucm/parser.c
+++ b/src/ucm/parser.c
@@ -2907,7 +2907,7 @@ int uc_mgr_scan_master_configs(const char **_list[])
 		snprintf(filename, sizeof(filename), "%s/ucm2/conf.virt.d",
 			 snd_config_topdir());
 
-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__sun) && !defined(ANDROID)
+#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__sun) && !defined(ANDROID)
 #define SORTFUNC	versionsort64
 #else
 #define SORTFUNC	alphasort64

--- a/src/ucm/ucm_exec.c
+++ b/src/ucm/ucm_exec.c
@@ -33,9 +33,13 @@
 #include <limits.h>
 #include <dirent.h>
 
-#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 #include <signal.h>
+#if defined(__DragonFly__)
+#define environ NULL /* XXX */
+#else
 extern char **environ;
+#endif
 #endif
 
 static pthread_mutex_t fork_lock = PTHREAD_MUTEX_INITIALIZER;

--- a/src/ucm/ucm_exec.c
+++ b/src/ucm/ucm_exec.c
@@ -33,7 +33,7 @@
 #include <limits.h>
 #include <dirent.h>
 
-#if defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 #include <signal.h>
 extern char **environ;
 #endif

--- a/src/ucm/ucm_exec.c
+++ b/src/ucm/ucm_exec.c
@@ -33,6 +33,11 @@
 #include <limits.h>
 #include <dirent.h>
 
+#if defined(__NetBSD__) || defined(__OpenBSD__)
+#include <signal.h>
+extern char **environ;
+#endif
+
 static pthread_mutex_t fork_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /*


### PR DESCRIPTION
to build alsa-lib on *BSD, small fix is required.
(reference: FreeBSD/NetBSD ports diff)

There is no problem to compile modified code on Linux(Debian-11), FreeBSD-13.1, NetBSD-current and OpenBSD-7.1.