### PR TITLE
Add ASUS ROG Zenith II Extreme configuration

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -46,6 +46,7 @@ USB-Audio.pcm.iec958_device {
 	"XONAR U5" 1
 	"XONAR SOUND CARD" 1
 	"Xonar SoundCard" 2
+	"Zenith II Main Audio" 1
 	
 	# The below don't have digital in/out, so prevent them from being opened.
 	"Andrea PureAudio USB-SA Headset" 999


### PR DESCRIPTION
This points iec958_device to the correct PCM device.

complements this [ALSA kernel patch](https://bugzilla.kernel.org/show_bug.cgi?id=211005).



