### PR TITLE
uapi: asoc: add element name macro

### DIFF
--- a/include/sound/uapi/asoc.h
+++ b/include/sound/uapi/asoc.h
@@ -186,6 +186,9 @@
 #define SND_SOC_TPLG_FSYNC_CM         SND_SOC_TPLG_FSYNC_CP
 #define SND_SOC_TPLG_FSYNC_CS         SND_SOC_TPLG_FSYNC_CC
 
+/* Max length of element name strings */
+#define SNDRV_CTL_ELEM_ID_NAME_MAXLEN 44
+
 /*
  * Block Header.
  * This header precedes all object and object arrays below.


### PR DESCRIPTION
Fix the build for users who include this file.

In file included from /home/lrg/work/sof/sof/tools/tplg_parser/tokens.c:24:
/usr/include/alsa/sound/uapi/asoc.h:220:21: error: ‘SNDRV_CTL_ELEM_ID_NAME_MAXLEN’ undeclared here (not in a function)
  220 |         char string[SNDRV_CTL_ELEM_ID_NAME_MAXLEN];
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>