### PR TITLE
clangd friendly headers

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -28,6 +28,9 @@
 #ifndef __ALSA_CONF_H
 #define __ALSA_CONF_H
 
+#include "input.h"
+#include "output.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/control.h
+++ b/include/control.h
@@ -28,6 +28,11 @@
 #ifndef __ALSA_CONTROL_H
 #define __ALSA_CONTROL_H
 
+#include <stddef.h>
+#include <unistd.h>
+#include "conf.h"
+#include "global.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/control_plugin.h
+++ b/include/control_plugin.h
@@ -31,6 +31,8 @@
 #ifndef __ALSA_CONTROL_PLUGIN_H
 #define __ALSA_CONTROL_PLUGIN_H
 
+#include "control.h"
+
 /**
  * \defgroup Control_Plugins Primitive Control Plugins
  * \ingroup Control

--- a/include/error.h
+++ b/include/error.h
@@ -28,6 +28,8 @@
 #ifndef __ALSA_ERROR_H
 #define __ALSA_ERROR_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/hwdep.h
+++ b/include/hwdep.h
@@ -28,6 +28,9 @@
 #ifndef __ALSA_HWDEP_H
 #define __ALSA_HWDEP_H
 
+#include <stddef.h>
+#include <unistd.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/input.h
+++ b/include/input.h
@@ -29,6 +29,8 @@
 #define __ALSA_INPUT_H
 
 #include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -28,6 +28,9 @@
 #ifndef __ALSA_MIXER_H
 #define __ALSA_MIXER_H
 
+#include "control.h"
+#include "pcm.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/mixer_abst.h
+++ b/include/mixer_abst.h
@@ -26,6 +26,8 @@
 #ifndef __ALSA_MIXER_ABST_H
 #define __ALSA_MIXER_ABST_H
 
+#include "mixer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/mixer_abst.h
+++ b/include/mixer_abst.h
@@ -99,10 +99,10 @@ struct sm_elem_ops {
 
 int snd_mixer_selem_compare(const snd_mixer_elem_t *c1, const snd_mixer_elem_t *c2);
 
-int snd_mixer_sbasic_info(const snd_mixer_class_t *class, sm_class_basic_t *info);
-void *snd_mixer_sbasic_get_private(const snd_mixer_class_t *class);
-void snd_mixer_sbasic_set_private(const snd_mixer_class_t *class, void *private_data);
-void snd_mixer_sbasic_set_private_free(const snd_mixer_class_t *class, void (*private_free)(snd_mixer_class_t *class));
+int snd_mixer_sbasic_info(const snd_mixer_class_t *mixer_class, sm_class_basic_t *info);
+void *snd_mixer_sbasic_get_private(const snd_mixer_class_t *mixer_class);
+void snd_mixer_sbasic_set_private(const snd_mixer_class_t *mixer_class, void *private_data);
+void snd_mixer_sbasic_set_private_free(const snd_mixer_class_t *mixer_class, void (*private_free)(snd_mixer_class_t *mixer_class));
 
 /** \} */
 

--- a/include/output.h
+++ b/include/output.h
@@ -29,6 +29,7 @@
 #define __ALSA_OUTPUT_H
 
 #include <stdarg.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/pcm.h
+++ b/include/pcm.h
@@ -29,6 +29,9 @@
 #ifndef __ALSA_PCM_H
 #define __ALSA_PCM_H
 
+#include "conf.h"
+#include "global.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/pcm_ioplug.h
+++ b/include/pcm_ioplug.h
@@ -31,6 +31,8 @@
 #ifndef __ALSA_PCM_IOPLUG_H
 #define __ALSA_PCM_IOPLUG_H
 
+#include "pcm.h"
+
 /**
  * \defgroup PCM_IOPlug External I/O plugin SDK
  * \ingroup Plugin_SDK

--- a/include/pcm_plugin.h
+++ b/include/pcm_plugin.h
@@ -32,6 +32,8 @@
 #ifndef __ALSA_PCM_PLUGIN_H
 #define __ALSA_PCM_PLUGIN_H
 
+#include "pcm.h"
+
 /**
  * \defgroup PCM_Plugins PCM Plugins
  * \ingroup PCM

--- a/include/pcm_rate.h
+++ b/include/pcm_rate.h
@@ -31,6 +31,8 @@
 #ifndef __ALSA_PCM_RATE_H
 #define __ALSA_PCM_RATE_H
 
+#include "pcm.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/rawmidi.h
+++ b/include/rawmidi.h
@@ -28,6 +28,9 @@
 #ifndef __ALSA_RAWMIDI_H
 #define __ALSA_RAWMIDI_H
 
+#include "conf.h"
+#include "global.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/seq.h
+++ b/include/seq.h
@@ -29,6 +29,12 @@
 #ifndef __ALSA_SEQ_H
 #define __ALSA_SEQ_H
 
+#include <stddef.h>
+#include <unistd.h>
+#include "conf.h"
+#include "seq_event.h"
+#include "timer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/seq_midi_event.h
+++ b/include/seq_midi_event.h
@@ -28,6 +28,9 @@
 #ifndef __ALSA_SEQ_MIDI_EVENT_H
 #define __ALSA_SEQ_MIDI_EVENT_H
 
+#include <stddef.h>
+#include "seq_event.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/timer.h
+++ b/include/timer.h
@@ -28,6 +28,8 @@
 #ifndef __ALSA_TIMER_H
 #define __ALSA_TIMER_H
 
+#include "conf.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/topology.h
+++ b/include/topology.h
@@ -21,6 +21,7 @@
 #ifndef __ALSA_TOPOLOGY_H
 #define __ALSA_TOPOLOGY_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
quality of life improvements when working with clangd enabled IDEs. these two patches fix issues when clangd parses the headers in isolation in a c++ compile context

---

* make headers self-contained
* avoid c++ keyword