### PR TITLE
avoid libdl detecion on *BSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,19 +255,10 @@ AC_ARG_WITH(libdl,
   [ have_libdl="$withval" ], [ have_libdl="yes" ])
 HAVE_LIBDL=
 if test "$have_libdl" = "yes"; then
-  case $host_os in
-  netbsd* | freebsd* | dragonfly* | openbsd*)
-    HAVE_LIBDL=yes
+  AC_SEARCH_LIBS([dlsym], [dl], [HAVE_LIBDL="yes"])
+  if test "$HAVE_LIBDL" = "yes" ; then
     AC_DEFINE([HAVE_LIBDL], 1, [Have libdl])
-    ;;
-  *)
-    AC_CHECK_LIB([dl], [dlsym], [HAVE_LIBDL="yes"])
-    if test "$HAVE_LIBDL" = "yes" ; then
-      ALSA_DEPLIBS="$ALSA_DEPLIBS -ldl"
-      AC_DEFINE([HAVE_LIBDL], 1, [Have libdl])
-    fi
-    ;;
-  esac
+  fi
 else
   AC_MSG_RESULT(no)
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -255,11 +255,19 @@ AC_ARG_WITH(libdl,
   [ have_libdl="$withval" ], [ have_libdl="yes" ])
 HAVE_LIBDL=
 if test "$have_libdl" = "yes"; then
-  AC_CHECK_LIB([dl], [dlsym], [HAVE_LIBDL="yes"])
-  if test "$HAVE_LIBDL" = "yes" ; then
-    ALSA_DEPLIBS="$ALSA_DEPLIBS -ldl"
+  case $host_os in
+  netbsd* | freebsd* | dragonfly* | openbsd*)
+    HAVE_LIBDL=yes
     AC_DEFINE([HAVE_LIBDL], 1, [Have libdl])
-  fi
+    ;;
+  *)
+    AC_CHECK_LIB([dl], [dlsym], [HAVE_LIBDL="yes"])
+    if test "$HAVE_LIBDL" = "yes" ; then
+      ALSA_DEPLIBS="$ALSA_DEPLIBS -ldl"
+      AC_DEFINE([HAVE_LIBDL], 1, [Have libdl])
+    fi
+    ;;
+  esac
 else
   AC_MSG_RESULT(no)
 fi


### PR DESCRIPTION
  NetBSD and OpenBSD has no libdl
  FreeBSD and DragonFlyBSD has libdl but dummy

  These OSes are no need to use -ldl to use dlopen()