### PR TITLE
ESTRPIPE definition change, and add OpenBSD support to test code

### DIFF
--- a/include/type_compat.h
+++ b/include/type_compat.h
@@ -26,7 +26,7 @@
 #define EBADFD EBADF
 #endif
 #ifndef ESTRPIPE
-#define ESTRPIPE EPIPE
+#define ESTRPIPE ESPIPE
 #endif
 
 #ifndef __u16

--- a/test/audio_time.c
+++ b/test/audio_time.c
@@ -4,8 +4,11 @@
  * helpful to verify the information reported by drivers.
  */
 
+#include "../include/config.h"
 #include <stdio.h>
+#if HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/latency.c
+++ b/test/latency.c
@@ -38,6 +38,15 @@
 #include <sys/time.h>
 #include <math.h>
 
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
+#endif
+
+#if defined(__OpenBSD__)
+#define sched_getparam(pid, parm) (-1)
+#define sched_setscheduler(pid, policy, parm) (-1)
+#endif
+
 typedef struct timespec timestamp_t;
 
 char *sched_policy = "rr";
@@ -839,9 +848,9 @@ int main(int argc, char *argv[])
 		if (ok) {
 #if 1
 			printf("Playback time = %li.%i, Record time = %li.%i, diff = %li\n",
-			       p_tstamp.tv_sec,
+			       (long)p_tstamp.tv_sec,
 			       (int)p_tstamp.tv_usec,
-			       c_tstamp.tv_sec,
+			       (long)c_tstamp.tv_sec,
 			       (int)c_tstamp.tv_usec,
 			       timediff(p_tstamp, c_tstamp));
 #endif

--- a/test/midifile.c
+++ b/test/midifile.c
@@ -71,7 +71,7 @@
 #endif
 
 #include <stdio.h>
-#include <values.h>
+#include <limits.h>
 
 #include <string.h>
 /*void exit(), free();*/
@@ -148,7 +148,7 @@ static void msginit ();
 static int msgleng ();
 static void msgadd ();
 static void biggermsg ();
-static int eputc (unsigned char c);
+static int eputc ();
 
 double mf_ticks2sec (unsigned long ticks, int division, unsigned long tempo);
 int mf_write_meta_event ();
@@ -328,7 +328,7 @@ readtrack ()			/* read a track chunk */
 
   if (Mf_interactive)
     {
-      Mf_toberead = MAXINT;
+      Mf_toberead = INT_MAX;
     }
   else
     {

--- a/test/namehint.c
+++ b/test/namehint.c
@@ -4,7 +4,8 @@
 int main(int argc, char *argv[])
 {
 	const char *iface = "pcm";
-	char **hints, **n;
+	void **hints;
+	char **n;
 	int err;
 
 	if (argc > 1)
@@ -12,7 +13,7 @@ int main(int argc, char *argv[])
 	err = snd_device_name_hint(-1, iface, &hints);
 	if (err < 0)
 		errx(1, "snd_device_name_hint error: %s", snd_strerror(err));
-	n = hints;
+	n = (char **)hints;
 	while (*n != NULL) {
 		printf("%s\n", *n);
 		n++;

--- a/test/pcm-multi-thread.c
+++ b/test/pcm-multi-thread.c
@@ -37,7 +37,7 @@ static char mode_suffix[] = {
 	'a', 's', 'h', 't', 'd', 'r'
 };
 
-static const char *devname = "default";
+static const char *pcmdev = "default";
 static int stream = SND_PCM_STREAM_PLAYBACK;
 static int num_threads = 1;
 static int periodsize = 16 * 1024;
@@ -127,7 +127,7 @@ static int parse_options(int argc, char **argv)
 	while ((c = getopt(argc, argv, "D:r:f:p:b:s:t:m:vq")) >= 0) {
 		switch (c) {
 		case 'D':
-			devname = optarg;
+			pcmdev = optarg;
 			break;
 		case 'r':
 			rate = atoi(optarg);
@@ -213,9 +213,9 @@ int main(int argc, char **argv)
 	if (parse_options(argc, argv))
 		return 1;
 
-	err = snd_pcm_open(&pcm, devname, stream, 0);
+	err = snd_pcm_open(&pcm, pcmdev, stream, 0);
 	if (err < 0) {
-		fprintf(stderr, "cannot open pcm %s\n", devname);
+		fprintf(stderr, "cannot open pcm %s\n", pcmdev);
 		return 1;
 	}
 

--- a/test/pcm.c
+++ b/test/pcm.c
@@ -12,6 +12,10 @@
 #include <sys/time.h>
 #include <math.h>
 
+#ifndef ESTRPIPE
+#define ESTRPIPE ESPIPE
+#endif
+
 static char *device = "plughw:0,0";			/* playback device */
 static snd_pcm_format_t format = SND_PCM_FORMAT_S16;	/* sample format */
 static unsigned int rate = 44100;			/* stream rate */

--- a/test/queue_timer.c
+++ b/test/queue_timer.c
@@ -100,9 +100,9 @@ main(int argc ATTRIBUTE_UNUSED, char **argv ATTRIBUTE_UNUSED)
 	prevdiff = diff;
 
 	fprintf(stderr, " real time: %12ld sec %8ld usec\nqueue time: %12ld sec %8ld usec\n      diff: %12ld sec %8ld usec\n  diffdiff: %12ld sec %8ld usec\n",
-		tv.tv_sec, tv.tv_usec,
+		(long)tv.tv_sec, tv.tv_usec,
 		(long)rtime->tv_sec, (long)rtime->tv_nsec / 1000,
-		diff.tv_sec, diff.tv_usec,
+		(long)diff.tv_sec, diff.tv_usec,
 		(long)diffdiff.tv_sec, (long)diffdiff.tv_usec);
 
 	if (diffdiff.tv_usec >  5000 ||


### PR DESCRIPTION
In alsa-utils' PR#186 (https://github.com/alsa-project/alsa-utils/pull/186), alternative of ESTRPIPE will be ESPIPE instead of EPIPE. This PR is library side of that fix.

(Currently EPIPE is defined when ESTRPIPE is not defined, but this cannot distinguish original EPIPE status and replaced-from-ESTRPIPE status.)

And, test suite (test/ directory, invoked "make check") needs same change. Included OpenBSD support and fix some compiler warnings.
