### PR TITLE
fix detection of android devices

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -4116,7 +4116,7 @@ static int config_file_load(snd_config_t *root, const char *fn, int errors)
 	if (!S_ISDIR(st.st_mode))
 		return config_file_open(root, fn);
 #ifndef DOC_HIDDEN
-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__sun) && !defined(ANDROID)
+#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__sun) && !defined(__ANDROID__)
 #define SORTFUNC	versionsort64
 #else
 #define SORTFUNC	alphasort64

--- a/src/pcm/pcm_direct.c
+++ b/src/pcm/pcm_direct.c
@@ -44,7 +44,7 @@
  *
  */
  
-#if !defined(__OpenBSD__) && !defined(__DragonFly__)
+#if !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__ANDROID__)
 union semun {
 	int              val;    /* Value for SETVAL */
 	struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */

--- a/src/ucm/parser.c
+++ b/src/ucm/parser.c
@@ -2915,7 +2915,7 @@ int uc_mgr_scan_master_configs(const char **_list[])
 		snprintf(filename, sizeof(filename), "%s/ucm2/conf.virt.d",
 			 snd_config_topdir());
 
-#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__sun) && !defined(ANDROID)
+#if defined(_GNU_SOURCE) && !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__sun) && !defined(__ANDROID__)
 #define SORTFUNC	versionsort64
 #else
 #define SORTFUNC	alphasort64


### PR DESCRIPTION
Hello, I'm part of the Termux team. Recently, I compiled your alsa-lib package on Termux and during the process I noticed that the lines where the OS is checked do not correctly specify the Android check value. Also in the `pcm_direct.c` code, a check is also needed, since the same structure is provided in Termux.