### PR TITLE
conf: add support for Amlogic AIU and AXG cards

### DIFF
--- a/src/conf/cards/Makefile.am
+++ b/src/conf/cards/Makefile.am
@@ -12,6 +12,7 @@ cfg_files = aliases.conf \
 	Audigy2.conf \
 	Aureon51.conf \
 	Aureon71.conf \
+	axg-sound-card.conf \
 	CA0106.conf \
 	CMI8338.conf \
 	CMI8338-SWIEC.conf \
@@ -29,6 +30,7 @@ cfg_files = aliases.conf \
 	FWSpeakers.conf \
 	FireWave.conf \
 	GUS.conf \
+	gx-sound-card.conf \
 	HDA-Intel.conf \
 	HdmiLpeAudio.conf \
 	ICE1712.conf \

--- a/src/conf/cards/axg-sound-card.conf
+++ b/src/conf/cards/axg-sound-card.conf
@@ -1,0 +1,65 @@
+#
+# Configuration for Amlogic AXG audio
+#
+
+axg-sound-card.pcm.default {
+	@args [ CARD  ]
+	@args.CARD {
+		type string
+	}
+	type softvol
+	slave.pcm {
+		type plug
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+		}
+	}
+	control {
+		name "PCM Playback Volume"
+		card $CARD
+	}
+}
+
+<confdir:pcm/hdmi.conf>
+
+axg-sound-card.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD {
+		type string
+	}
+	@args.AES0 {
+		type integer
+	}
+	@args.AES1 {
+		type integer
+	}
+	@args.AES2 {
+		type integer
+	}
+	@args.AES3 {
+		type integer
+	}
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 0
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				name "IEC958 Playback Default"
+				interface PCM
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+}

--- a/src/conf/cards/gx-sound-card.conf
+++ b/src/conf/cards/gx-sound-card.conf
@@ -1,0 +1,106 @@
+#
+# Configuration for Amlogic AIU audio
+#
+
+gx-sound-card.pcm.default {
+	@args [ CARD  ]
+	@args.CARD {
+		type string
+	}
+	type softvol
+	slave.pcm {
+		type plug
+		slave {
+			pcm {
+				type hw
+				card $CARD
+				device 0
+			}
+		}
+	}
+	control {
+		name "PCM Playback Volume"
+		card $CARD
+	}
+}
+
+<confdir:pcm/hdmi.conf>
+
+gx-sound-card.pcm.hdmi.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD {
+		type string
+	}
+	@args.AES0 {
+		type integer
+	}
+	@args.AES1 {
+		type integer
+	}
+	@args.AES2 {
+		type integer
+	}
+	@args.AES3 {
+		type integer
+	}
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 0
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				name "IEC958 Playback Default"
+				interface PCM
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+}
+
+<confdir:pcm/iec958.conf>
+
+gx-sound-card.pcm.iec958.0 {
+	@args [ CARD AES0 AES1 AES2 AES3 ]
+	@args.CARD {
+		type string
+	}
+	@args.AES0 {
+		type integer
+	}
+	@args.AES1 {
+		type integer
+	}
+	@args.AES2 {
+		type integer
+	}
+	@args.AES3 {
+		type integer
+	}
+	type hooks
+	slave.pcm {
+		type hw
+		card $CARD
+		device 1
+	}
+	hooks.0 {
+		type ctl_elems
+		hook_args [
+			{
+				name "IEC958 Playback Default"
+				interface PCM
+				lock true
+				preserve true
+				optional true
+				value [ $AES0 $AES1 $AES2 $AES3 ]
+			}
+		]
+	}
+	hint.device 1
+}


### PR DESCRIPTION
This submission adds generic card confs for the Amlogic AIU and AXG audio cards. AIU is used with GXBB/GXL/GXM boards and supports HDMI and hinted S/PDIF output. The AXG conf is used with G12A/G12B/SM1 boards and supports HDMI only output. Hinting S/PDIF support does not work with AXG due to the card always presenting three outputs (with internal routing controlling what they are) so the hint always returns true.

This is an AIU device with HDMI and S/PDIF hardware:
```
WP2:~ # aplay -L
null
    Discard all samples (playback) or generate zero samples (capture)
default:CARD=WETEKPLAY2
    WETEK-PLAY2, 
    Default Audio Device
sysdefault:CARD=WETEKPLAY2
    WETEK-PLAY2, 
    Default Audio Device
iec958:CARD=WETEKPLAY2,DEV=0
    WETEK-PLAY2, 
    IEC958 (S/PDIF) Digital Audio Output
hdmi:CARD=WETEKPLAY2,DEV=0
    WETEK-PLAY2, 
    HDMI Audio Output
WP2:~ # aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: WETEKPLAY2 [WETEK-PLAY2], device 0: fe.dai-link-0 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: WETEKPLAY2 [WETEK-PLAY2], device 1: fe.dai-link-1 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
```
This is an AXG device with HDMI only hardware:
```
N2PLUS:~ # aplay -L
null
    Discard all samples (playback) or generate zero samples (capture)
default:CARD=ODROIDN2
    ODROID-N2, 
    Default Audio Device
sysdefault:CARD=ODROIDN2
    ODROID-N2, 
    Default Audio Device
hdmi:CARD=ODROIDN2,DEV=0
    ODROID-N2, 
    HDMI Audio Output
N2PLUS:~ # aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: ODROIDN2 [ODROID-N2], device 0: fe.dai-link-0 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: ODROIDN2 [ODROID-N2], device 1: fe.dai-link-1 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: ODROIDN2 [ODROID-N2], device 2: fe.dai-link-2 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
```
The confs have been in use with the Kodi distro LibreELEC for around two years and other distros supporting Amlogic boards on upstream kernels (Armbian, Manjaro, etc.) have borrowed them from our repo too. The prime reason for submitting them is to allow everyone to drop some patches. Although the confs are known-working it would be great if someone with better alsa knowlege than myself could vet them for correctness.

ping @jeromebrunet for awareness