### PR TITLE
Set C-Media USB 7.1 sound card to six_channel for surround40

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -27,6 +27,7 @@ USB-Audio.pcm.use_dmix {
 USB-Audio.pcm.surround40_type {
 	"AudioPhile" two_stereo_devices
 	"Audiophile USB (tm)" two_stereo_devices
+	"ICUSBAUDIO7D" six_channels
 	"OmniStudio" two_stereo_devices
 	"Quattro" two_stereo_devices
 	"SB Audigy 2 NX" six_channels


### PR DESCRIPTION
This 7.1 analog sound card identifies as the following: 0d8c:0102 C-Media Electronics, Inc. CM106 Like Sound Device (lsusb)
 1 [ICUSBAUDIO7D   ]: USB-Audio - ICUSBAUDIO7D (/proc/asound/cards)

It has the following four-channel analog stream layout:
  Interface 1
    Altset 3
    Format: S16_LE
    Channels: 4
    Endpoint: 6 OUT (ADAPTIVE)
    Rates: 44100, 48000
    Bits: 16
    Channel map: FL FR FC LFE
(/proc/asound/card1/stream0)

This layout makes it impossible to play audio to the surround (SL/SR) speakers plugged into the "Surround" jack in 4 channel mode.  Instead, set six_channel so that the six-channel layout will be used to access those speakers:
  Interface 1
    Altset 4
    Format: S16_LE
    Channels: 6
    Endpoint: 6 OUT (ADAPTIVE)
    Rates: 44100, 48000
    Bits: 16
    Channel map: FL FR FC LFE SL SR

Tested with speaker-test -Dsurround40:CARD=ICUSBAUDIO7D,DEV=0 -c4

The speaker system that required surround40 in order to downmix LFE into the front/rear mix is a Klipsch ProMedia v.2-400, which has 4 speakers and a subwoofer with an internal crossover, connected via front and rear stereo analog cables.