### PR TITLE
pcm: fix minor bug in ioctl

### DIFF
--- a/src/pcm/pcm_hw.c
+++ b/src/pcm/pcm_hw.c
@@ -672,7 +672,7 @@ static int snd_pcm_hw_prepare(snd_pcm_t *pcm)
 
 	if (hw->prepare_reset_sw_params) {
 		snd_pcm_sw_params_current_no_lock(pcm, &sw_params);
-		if (ioctl(hw->fd, SNDRV_PCM_IOCTL_SW_PARAMS, sw_params) < 0) {
+		if (ioctl(hw->fd, SNDRV_PCM_IOCTL_SW_PARAMS, &sw_params) < 0) {
 			err = -errno;
 			SYSMSG("SNDRV_PCM_IOCTL_SW_PARAMS failed (%i)", err);
 			return err;


### PR DESCRIPTION
Commit 2115cdb added a new call to the `SNDRV_PCM_IOCTL_SW_PARAMS` ioctl on line 675 of src/pcm/pcm_hw.c, but passed the `sw_params` argument by value; this should be passed by pointer.

I ran across this in the context of the direwolf software modem for amateur radio; debugging details are in
https://groups.io/g/direwolf/message/8286

Fixes #329