### PR TITLE
configure: Add large file support via CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -743,6 +743,9 @@ if test ! -L "$srcdir"/include/alsa ; then
   ln -sf . "$srcdir"/include/alsa
 fi
 
+dnl enable large file support
+CFLAGS="${CFLAGS} -D_FILE_OFFSET_BITS=64"
+
 AC_OUTPUT(Makefile doc/Makefile doc/pictures/Makefile doc/doxygen.cfg \
 	  include/Makefile include/sound/Makefile include/sound/uapi/Makefile \
 	  src/Versions src/Makefile \


### PR DESCRIPTION
Currently scanelf (pax-utils) detects missing LFS support in the following files/calls:
fopen,__open_2,mmap,lseek,open /usr/lib/libasound.so.2.0.0 fopen,open /usr/lib/libatopology.so.2.0.0

Note that this may cause problems on systems with a 32-bit kernel, but I've tested playing audio on a more recent 32-bit system with a 64-bit kernel.

Notably AC_SYS_LARGEFILE (currently used in alsa-utils for example) did not solve the issue for my case, whereas FILE_OFFSET_BITS did.

Let me know if you'd prefer an alternative approach!