### PR TITLE
Documentation cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -781,9 +781,11 @@ EOF
 fi
 cat >> include/asoundlib.h <<EOF
 
+#ifndef DOC_HIDDEN
 #ifndef __GNUC__
 #define __inline__ inline
 #endif
+#endif /* DOC_HIDDEN */
 
 #include <alsa/asoundef.h>
 #include <alsa/version.h>

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -36,6 +36,7 @@ INPUT            = @top_srcdir@/doc/index.doxygen \
 		   @top_srcdir@/src/input.c \
 		   @top_srcdir@/src/output.c \
 		   @top_srcdir@/src/conf.c \
+		   @top_srcdir@/src/confeval.c \
 		   @top_srcdir@/src/confmisc.c \
 		   @top_srcdir@/src/names.c \
 		   @top_srcdir@/src/shmarea.c \

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -110,7 +110,7 @@ EXCLUDE		 = @top_srcdir@/src/control/control_local.h \
 RECURSIVE	 = YES
 FILE_PATTERNS    = *.c *.h
 EXAMPLE_PATH     = @top_srcdir@/test
-IMAGE_PATH	 = pictures
+IMAGE_PATH	 = @top_srcdir@/doc/pictures
 QUIET            = YES
 
 EXTRACT_ALL	 = NO

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -128,7 +128,8 @@ PREDEFINED	 = DOXYGEN PIC "DOC_HIDDEN" \
 		   ALSA_PCM_NEW_HW_PARAMS_API \
 		   _POSIX_C_SOURCE \
 		   "use_default_symbol_version(x,y,z)=" \
-		   "link_warning(x,y)="
+		   "link_warning(x,y)=" \
+		   __attribute__((x))=
 
 OPTIMIZE_OUTPUT_FOR_C = YES	# doxygen 1.2.6 option
 TYPEDEF_HIDES_STRUCT = YES	# needed in doxygen >= 1.5.4

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -42,6 +42,7 @@ INPUT            = @top_srcdir@/doc/index.doxygen \
 		   @top_srcdir@/src/userfile.c \
 		   @top_srcdir@/src/control/cards.c \
 		   @top_srcdir@/src/control/control.c \
+		   @top_srcdir@/src/control/control_ext.c \
 		   @top_srcdir@/src/control/control_plugin.c \
 		   @top_srcdir@/src/control/control_hw.c \
 		   @top_srcdir@/src/control/control_remap.c \

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -50,6 +50,7 @@ INPUT            = @top_srcdir@/doc/index.doxygen \
 		   @top_srcdir@/src/control/control_shm.c \
 		   @top_srcdir@/src/control/ctlparse.c \
 		   @top_srcdir@/src/control/hcontrol.c \
+		   @top_srcdir@/src/control/namehint.c \
 		   @top_srcdir@/src/control/setup.c \
 		   @top_srcdir@/src/control/tlv.c \
 		   @top_srcdir@/src/mixer \

--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -112,6 +112,7 @@ EXCLUDE		 = @top_srcdir@/src/control/control_local.h \
 		   @top_srcdir@/src/topology/tplg_local.h
 RECURSIVE	 = YES
 FILE_PATTERNS    = *.c *.h
+INCLUDE_PATH     = @top_builddir@/include
 EXAMPLE_PATH     = @top_srcdir@/test
 IMAGE_PATH	 = @top_srcdir@/doc/pictures
 QUIET            = YES

--- a/include/asoundef.h
+++ b/include/asoundef.h
@@ -215,6 +215,8 @@ extern "C" {
 #define CEA861_AUDIO_INFOFRAME_DB5_DM_INH_PROHIBITED (1<<7) /**< stereo downmis prohibited */
 #define CEA861_AUDIO_INFOFRAME_DB5_LSV		(0xf<<3) /**< mask - level-shift values */
 
+/** \} */
+
 /**
  * \defgroup MIDI_Interface Constants for MIDI v1.0
  * Constants for MIDI v1.0.
@@ -223,6 +225,8 @@ extern "C" {
 
 #define MIDI_CHANNELS			16	/**< Number of channels per port/cable. */
 #define MIDI_GM_DRUM_CHANNEL		(10-1)	/**< Channel number for GM drums. */
+
+/** \} */
 
 /**
  * \defgroup MIDI_Commands MIDI Commands
@@ -332,8 +336,6 @@ extern "C" {
 #define MIDI_CTL_OMNI_ON		0x7d	/**< Omni on */
 #define MIDI_CTL_MONO1			0x7e	/**< Mono1 */
 #define MIDI_CTL_MONO2			0x7f	/**< Mono2 */
-
-/** \} */
 
 /** \} */
 

--- a/include/conf.h
+++ b/include/conf.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /**
- *  \defgroup Config Configuration Interface
+ *  \defgroup Configuration Configuration Interface
  *  The configuration functions and types allow you to read, enumerate,
  *  modify and write the contents of ALSA configuration files.
  *  \{
@@ -109,6 +109,16 @@ int snd_config_search_definition(snd_config_t *config,
 				 const char *base, const char *key,
 				 snd_config_t **result);
 
+/**
+ * \brief custom expansion callback
+ * \param[out] dst The function puts the handle to the new configuration
+ *                 node at the address specified by \a dst.
+ * \param[in] s string the string to be expanded
+ * \param[in] private_data Handle to the \c private_data node.
+ * \return A non-negative value if successful, otherwise a negative error code.
+ *
+ * Use a function of this type to define a custom expansion 
+ */
 typedef int (*snd_config_expand_fcn_t)(snd_config_t **dst, const char *s, void *private_data);
 
 int snd_config_expand_custom(snd_config_t *config, snd_config_t *root,

--- a/include/control.h
+++ b/include/control.h
@@ -374,10 +374,6 @@ int snd_card_get_index(const char *name);
 int snd_card_get_name(int card, char **name);
 int snd_card_get_longname(int card, char **name);
 
-int snd_device_name_hint(int card, const char *iface, void ***hints);
-int snd_device_name_free_hint(void **hints);
-char *snd_device_name_get_hint(const void *hint, const char *id);
-
 int snd_ctl_open(snd_ctl_t **ctl, const char *name, int mode);
 int snd_ctl_open_lconf(snd_ctl_t **ctl, const char *name, int mode, snd_config_t *lconf);
 int snd_ctl_open_fallback(snd_ctl_t **ctl, snd_config_t *root, const char *name, const char *orig_name, int mode);
@@ -794,6 +790,20 @@ int snd_sctl_build(snd_sctl_t **ctl, snd_ctl_t *handle, snd_config_t *config,
 int snd_sctl_free(snd_sctl_t *handle);
 int snd_sctl_install(snd_sctl_t *handle);
 int snd_sctl_remove(snd_sctl_t *handle);
+
+/** \} */
+
+/**
+ *  \defgroup Hint Name Hint Interface
+ *  \ingroup Configuration
+ *  The name hint interface - get descriptive information about a device
+ *  (name, description, input/output).
+ *  \{
+ */
+
+int snd_device_name_hint(int card, const char *iface, void ***hints);
+int snd_device_name_free_hint(void **hints);
+char *snd_device_name_get_hint(const void *hint, const char *id);
 
 /** \} */
 

--- a/include/global.h
+++ b/include/global.h
@@ -128,9 +128,11 @@ int snd_async_handler_get_fd(snd_async_handler_t *handler);
 int snd_async_handler_get_signo(snd_async_handler_t *handler);
 void *snd_async_handler_get_callback_private(snd_async_handler_t *handler);
 
+#ifdef HAVE_SYS_SHM_H
 struct snd_shm_area *snd_shm_area_create(int shmid, void *ptr);
 struct snd_shm_area *snd_shm_area_share(struct snd_shm_area *area);
 int snd_shm_area_destroy(struct snd_shm_area *area);
+#endif
 
 int snd_user_file(const char *file, char **result);
 

--- a/include/global.h
+++ b/include/global.h
@@ -128,11 +128,9 @@ int snd_async_handler_get_fd(snd_async_handler_t *handler);
 int snd_async_handler_get_signo(snd_async_handler_t *handler);
 void *snd_async_handler_get_callback_private(snd_async_handler_t *handler);
 
-#ifdef HAVE_SYS_SHM_H
 struct snd_shm_area *snd_shm_area_create(int shmid, void *ptr);
 struct snd_shm_area *snd_shm_area_share(struct snd_shm_area *area);
 int snd_shm_area_destroy(struct snd_shm_area *area);
-#endif
 
 int snd_user_file(const char *file, char **result);
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -47,7 +47,7 @@ typedef struct _snd_mixer_elem snd_mixer_elem_t;
 
 /** 
  * \brief Mixer callback function
- * \param mixer Mixer handle
+ * \param ctl Mixer handle
  * \param mask event mask
  * \param elem related mixer element (if any)
  * \return 0 on success otherwise a negative error code

--- a/include/pcm.h
+++ b/include/pcm.h
@@ -343,6 +343,7 @@ typedef enum _snd_pcm_tstamp {
 	SND_PCM_TSTAMP_LAST = SND_PCM_TSTAMP_ENABLE
 } snd_pcm_tstamp_t;
 
+/** PCM timestamp type */
 typedef enum _snd_pcm_tstamp_type {
 	SND_PCM_TSTAMP_TYPE_GETTIMEOFDAY = 0,	/**< gettimeofday equivalent */
 	SND_PCM_TSTAMP_TYPE_MONOTONIC,	/**< posix_clock_monotonic equivalent */
@@ -350,6 +351,7 @@ typedef enum _snd_pcm_tstamp_type {
 	SND_PCM_TSTAMP_TYPE_LAST = SND_PCM_TSTAMP_TYPE_MONOTONIC_RAW,
 } snd_pcm_tstamp_type_t;
 
+/** PCM audio timestamp type */
 typedef enum _snd_pcm_audio_tstamp_type {
 	/**
 	 * first definition for backwards compatibility only,
@@ -364,24 +366,22 @@ typedef enum _snd_pcm_audio_tstamp_type {
 	SND_PCM_AUDIO_TSTAMP_TYPE_LAST = SND_PCM_AUDIO_TSTAMP_TYPE_LINK_SYNCHRONIZED
 } snd_pcm_audio_tstamp_type_t;
 
+/** PCM audio timestamp config */
 typedef struct _snd_pcm_audio_tstamp_config {
 	/* 5 of max 16 bits used */
-	unsigned int type_requested:4;
-	unsigned int report_delay:1; /* add total delay to A/D or D/A */
+	unsigned int type_requested:4; /**< requested audio tstamp type */
+	unsigned int report_delay:1; /**< add total delay to A/D or D/A */
 } snd_pcm_audio_tstamp_config_t;
 
+/** PCM audio timestamp report */
 typedef struct _snd_pcm_audio_tstamp_report {
 	/* 6 of max 16 bits used for bit-fields */
 
-	/* for backwards compatibility */
-	unsigned int valid:1;
+	unsigned int valid:1; /**< for backwards compatibility */
+	unsigned int actual_type:4; /**< actual type if hardware could not support requested timestamp */
 
-	/* actual type if hardware could not support requested timestamp */
-	unsigned int actual_type:4;
-
-	/* accuracy represented in ns units */
-	unsigned int accuracy_report:1; /* 0 if accuracy unknown, 1 if accuracy field is valid */
-	unsigned int accuracy; /* up to 4.29s, will be packed in separate field  */
+	unsigned int accuracy_report:1; /**< 0 if accuracy unknown, 1 if accuracy field is valid */
+	unsigned int accuracy; /**< up to 4.29s in ns units, will be packed in separate field  */
 } snd_pcm_audio_tstamp_report_t;
 
 /** Unsigned frames quantity */

--- a/include/topology.h
+++ b/include/topology.h
@@ -840,7 +840,7 @@ struct snd_tplg_tlv_dbscale_template {
 	int mute;			/*!< is min dB value mute ? */
 };
 
-/** \struct snd_tplg_channel_template
+/** \struct snd_tplg_channel_elem
  * \brief Template type for single channel mapping.
  */
 struct snd_tplg_channel_elem {
@@ -1021,26 +1021,26 @@ struct snd_tplg_pcm_template {
  * hardware config, i.e. hardware audio formats.
  */
 struct snd_tplg_hw_config_template {
-	int id;                         /* unique ID - - used to match */
-	unsigned int fmt;               /* SND_SOC_DAI_FORMAT_ format value */
-	unsigned char clock_gated;      /* SND_SOC_TPLG_DAI_CLK_GATE_ value */
-	unsigned char  invert_bclk;     /* 1 for inverted BCLK, 0 for normal */
-	unsigned char  invert_fsync;    /* 1 for inverted frame clock, 0 for normal */
-	unsigned char  bclk_provider;   /* SND_SOC_TPLG_BCLK_ value */
-	unsigned char  fsync_provider;  /* SND_SOC_TPLG_FSYNC_ value */
-	unsigned char  mclk_direction;  /* SND_SOC_TPLG_MCLK_ value */
-	unsigned short reserved;        /* for 32bit alignment */
-	unsigned int mclk_rate;	        /* MCLK or SYSCLK freqency in Hz */
-	unsigned int bclk_rate;	        /* BCLK freqency in Hz */
-	unsigned int fsync_rate;        /* frame clock in Hz */
-	unsigned int tdm_slots;         /* number of TDM slots in use */
-	unsigned int tdm_slot_width;    /* width in bits for each slot */
-	unsigned int tx_slots;          /* bit mask for active Tx slots */
-	unsigned int rx_slots;          /* bit mask for active Rx slots */
-	unsigned int tx_channels;       /* number of Tx channels */
-	unsigned int *tx_chanmap;       /* array of slot number */
-	unsigned int rx_channels;       /* number of Rx channels */
-	unsigned int *rx_chanmap;       /* array of slot number */
+	int id;                         /*!< unique ID - - used to match */
+	unsigned int fmt;               /*!< SND_SOC_DAI_FORMAT_ format value */
+	unsigned char clock_gated;      /*!< SND_SOC_TPLG_DAI_CLK_GATE_ value */
+	unsigned char  invert_bclk;     /*!< 1 for inverted BCLK, 0 for normal */
+	unsigned char  invert_fsync;    /*!< 1 for inverted frame clock, 0 for normal */
+	unsigned char  bclk_provider;   /*!< SND_SOC_TPLG_BCLK_ value */
+	unsigned char  fsync_provider;  /*!< SND_SOC_TPLG_FSYNC_ value */
+	unsigned char  mclk_direction;  /*!< SND_SOC_TPLG_MCLK_ value */
+	unsigned short reserved;        /*!< for 32bit alignment */
+	unsigned int mclk_rate;	        /*!< MCLK or SYSCLK freqency in Hz */
+	unsigned int bclk_rate;	        /*!< BCLK freqency in Hz */
+	unsigned int fsync_rate;        /*!< frame clock in Hz */
+	unsigned int tdm_slots;         /*!< number of TDM slots in use */
+	unsigned int tdm_slot_width;    /*!< width in bits for each slot */
+	unsigned int tx_slots;          /*!< bit mask for active Tx slots */
+	unsigned int rx_slots;          /*!< bit mask for active Rx slots */
+	unsigned int tx_channels;       /*!< number of Tx channels */
+	unsigned int *tx_chanmap;       /*!< array of slot number */
+	unsigned int rx_channels;       /*!< number of Rx channels */
+	unsigned int *rx_chanmap;       /*!< array of slot number */
 };
 
 /** \struct snd_tplg_dai_template
@@ -1071,15 +1071,15 @@ struct snd_tplg_link_template {
 	struct snd_tplg_stream_template *stream;       /*!< supported configs */
 
 	struct snd_tplg_hw_config_template *hw_config; /*!< supported HW configs */
-	int num_hw_configs;		/* number of hw configs */
-	int default_hw_config_id;       /* default hw config ID for init */
+	int num_hw_configs;		/*!< number of hw configs */
+	int default_hw_config_id;       /*!< default hw config ID for init */
 
-	unsigned int flag_mask;         /* bitmask of flags to configure */
-	unsigned int flags;             /* SND_SOC_TPLG_LNK_FLGBIT_* flag value */
+	unsigned int flag_mask;         /*!< bitmask of flags to configure */
+	unsigned int flags;             /*!< SND_SOC_TPLG_LNK_FLGBIT_* flag value */
 	struct snd_soc_tplg_private *priv; /*!< private data */
 };
 
-/** \struct snd_tplg_obj_template
+/** \struct snd_tplg_obj_template_t
  * \brief Generic Template Object
  */
 typedef struct snd_tplg_obj_template {
@@ -1152,7 +1152,13 @@ int snd_tplg_set_version(snd_tplg_t *tplg, unsigned int version);
  * \brief Save the topology to the text configuration string.
  * \param tplg Topology instance.
  * \param dst A pointer to string with result (malloc).
+ * \param flags save mode
  * \return Zero on success, otherwise a negative error code
+ *
+ * Valid flags are
+ *    - SND_TPLG_SAVE_SORT
+ *    - SND_TPLG_SAVE_GROUPS
+ *    - SND_TPLG_SAVE_NOCHECK
  */
 int snd_tplg_save(snd_tplg_t *tplg, char **dst, int flags);
 
@@ -1161,6 +1167,7 @@ int snd_tplg_save(snd_tplg_t *tplg, char **dst, int flags);
  * \param tplg Topology instance.
  * \param bin Binary topology input buffer.
  * \param size Binary topology input buffer size.
+ * \param dflags - not used, must be set to 0.
  * \return Zero on success, otherwise a negative error code
  */
 int snd_tplg_decode(snd_tplg_t *tplg, void *bin, size_t size, int dflags);

--- a/include/topology.h
+++ b/include/topology.h
@@ -254,8 +254,6 @@ extern "C" {
  * And data of these sections will be merged in the same order as they are
  * in the list, as the element's private data for kernel.
  *
- * </pre>
- *
  *  <h6>Vendor Tokens</h6>
  * A vendor token list is defined as a new section. Each token element is
  * a pair of string ID and integer value. And both the ID and value are

--- a/include/topology.h
+++ b/include/topology.h
@@ -219,7 +219,7 @@ extern "C" {
  *
  * <pre>
  * SectionData."data element name" {
- *	index "1"	#Index number
+ *	index "1"	# Index number
  *	tuples [
  *		"id of the 1st vendor tuples section"
  *		"id of the 2nd vendor tuples section"
@@ -637,7 +637,7 @@ extern "C" {
  *		...
  *	]
  *
- *	default_hw_conf_id "1"		#default HW config ID for init
+ *	default_hw_conf_id "1"		# default HW config ID for init
  *
  *	# Optional boolean flags
  *	symmetric_rates			"true"

--- a/include/topology.h
+++ b/include/topology.h
@@ -1167,7 +1167,7 @@ int snd_tplg_save(snd_tplg_t *tplg, char **dst, int flags);
  */
 int snd_tplg_decode(snd_tplg_t *tplg, void *bin, size_t size, int dflags);
 
-/* \} */
+/** \} */
 
 #ifdef __cplusplus
 }

--- a/include/use-case.h
+++ b/include/use-case.h
@@ -534,7 +534,7 @@ static __inline__ int snd_use_case_verb_list(snd_use_case_mgr_t *uc_mgr,
 
 /**
  * \brief Parse control element identifier
- * \param elem_id Element identifier
+ * \param dst Element identifier
  * \param ucm_id Use case identifier
  * \param value String value to be parsed
  * \return Zero if success, otherwise a negative error code

--- a/include/use-case.h
+++ b/include/use-case.h
@@ -325,10 +325,10 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *      - playback control device name
  *   - PlaybackVolume
  *      - playback control volume identifier string
- *	- can be parsed using snd_use_case_parse_ctl_elem_id()
+ *      - can be parsed using #snd_use_case_parse_ctl_elem_id()
  *   - PlaybackSwitch
  *      - playback control switch identifier string
- *	- can be parsed using snd_use_case_parse_ctl_elem_id()
+ *	    - can be parsed using #snd_use_case_parse_ctl_elem_id()
  *   - PlaybackPriority
  *      - priority value (1-10000), higher value means higher priority
  *   - CaptureRate
@@ -345,20 +345,20 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *      - capture control device name
  *   - CaptureVolume
  *      - capture control volume identifier string
- *	- can be parsed using snd_use_case_parse_ctl_elem_id()
+ *	    - can be parsed using #snd_use_case_parse_ctl_elem_id()
  *   - CaptureSwitch
  *      - capture control switch identifier string
- *	- can be parsed using snd_use_case_parse_ctl_elem_id()
+ *	    - can be parsed using #snd_use_case_parse_ctl_elem_id()
  *   - CapturePriority
  *      - priority value (1-10000), higher value means higher priority
  *   - PlaybackMixer
  *      - name of playback mixer
  *   - PlaybackMixerElem
  *      - mixer element playback identifier
- *	- can be parsed using snd_use_case_parse_selem_id()
+ *	    - can be parsed using #snd_use_case_parse_selem_id()
  *   - PlaybackMasterElem
  *      - mixer element playback identifier for the master control
- *	- can be parsed using snd_use_case_parse_selem_id()
+ *	    - can be parsed using #snd_use_case_parse_selem_id()
  *   - PlaybackMasterType
  *      - type of the master volume control
  *      - Valid values: "soft" (software attenuation)
@@ -366,10 +366,10 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *      - name of capture mixer
  *   - CaptureMixerElem
  *      - mixer element capture identifier
- *	- can be parsed using snd_use_case_parse_selem_id()
+ *	    - can be parsed using #snd_use_case_parse_selem_id()
  *   - CaptureMasterElem
  *      - mixer element playback identifier for the master control
- *	- can be parsed using snd_use_case_parse_selem_id()
+ *	    - can be parsed using #snd_use_case_parse_selem_id()
  *   - CaptureMasterType
  *      - type of the master volume control
  *      - Valid values: "soft" (software attenuation)
@@ -405,9 +405,9 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
  *        but that's application policy configuration that doesn't belong
  *        to UCM configuration files.
  *   - MinBufferLevel
- *	- This is used on platform where reported buffer level is not accurate.
- *	  E.g. "512", which holds 512 samples in device buffer. Note: this will
- *	  increase latency.
+ *	 - This is used on platform where reported buffer level is not accurate.
+ *	   E.g. "512", which holds 512 samples in device buffer. Note: this will
+ *	   increase latency.
  */
 int snd_use_case_get(snd_use_case_mgr_t *uc_mgr,
                      const char *identifier,
@@ -436,24 +436,24 @@ int snd_use_case_geti(snd_use_case_mgr_t *uc_mgr,
  * \return Zero if success, otherwise a negative error code
  *
  * Known identifiers:
- *   - _fboot			- execute the fixed boot sequence (value = NULL)
- *   - _boot			- execute the boot sequence (value = NULL)
- *				   - only when driver controls identifiers are changed
- *				     (otherwise the old control values are restored)
- *   - _defaults		- execute the 'defaults' sequence (value = NULL)
- *   - _verb			- set current verb = value
- *   - _enadev			- enable given device = value
- *   - _disdev			- disable given device = value
- *   - _swdev/{old_device}	- new_device = value
- *				  - disable old_device and then enable new_device
- *				  - if old_device is not enabled just return
- *				  - check transmit sequence firstly
- *   - _enamod			- enable given modifier = value
- *   - _dismod			- disable given modifier = value
+ *   - _fboot           - execute the fixed boot sequence (value = NULL)
+ *   - _boot            - execute the boot sequence (value = NULL)
+ *                      - only when driver controls identifiers are changed
+ *                        (otherwise the old control values are restored)
+ *   - _defaults        - execute the 'defaults' sequence (value = NULL)
+ *   - _verb            - set current verb = value
+ *   - _enadev          - enable given device = value
+ *   - _disdev          - disable given device = value
+ *   - _swdev/{old_device} - new_device = value
+ *                      - disable old_device and then enable new_device
+ *                      - if old_device is not enabled just return
+ *                      - check transmit sequence firstly
+ *   - _enamod          - enable given modifier = value
+ *   - _dismod          - disable given modifier = value
  *   - _swmod/{old_modifier}	- new_modifier = value
- *				  - disable old_modifier and then enable new_modifier
- *				  - if old_modifier is not enabled just return
- *				  - check transmit sequence firstly
+ *                      - disable old_modifier and then enable new_modifier
+ *                      - if old_modifier is not enabled just return
+ *                      - check transmit sequence firstly
  */
 int snd_use_case_set(snd_use_case_mgr_t *uc_mgr,
                      const char *identifier,

--- a/src/async.c
+++ b/src/async.c
@@ -29,7 +29,9 @@
 #include <signal.h>
 
 static struct sigaction previous_action;
+#ifndef DOC_HIDDEN
 #define MAX_SIG_FUNCTION_CODE 10 /* i.e. SIG_DFL SIG_IGN SIG_HOLD et al */
+#endif /* DOC_HIDDEN */
 
 #ifdef SND_ASYNC_RT_SIGNAL
 /** async signal number */

--- a/src/conf.c
+++ b/src/conf.c
@@ -527,7 +527,7 @@ static inline void snd_config_unlock(void) { }
 #endif
 
 /*
- * Add a diretory to the paths to search included files.
+ * Add a directory to the paths to search included files.
  * param fd -  File object that owns these paths to search files included by it.
  * param dir - Path of the directory to add. Allocated externally and need to
 *              be freed manually later.
@@ -584,6 +584,8 @@ static void free_include_paths(struct filedesc *fd)
 	}
 }
 
+#endif /* DOC_HIDDEN */
+
 /**
  * \brief Returns the default top-level config directory
  * \return The top-level config directory path string
@@ -604,6 +606,8 @@ const char *snd_config_topdir(void)
 	}
 	return topdir;
 }
+
+#ifndef DOC_HIDDEN
 
 static char *_snd_config_path(const char *name)
 {
@@ -1700,7 +1704,7 @@ static int _snd_config_save_children(snd_config_t *config, snd_output_t *out,
 	}
 	return 0;
 }
-#endif
+#endif /* DOC_HIDDEN */
 
 
 /**
@@ -2873,6 +2877,26 @@ int snd_config_imake_string(snd_config_t **config, const char *id, const char *v
 	return 0;
 }
 
+/**
+ * \brief Creates a string configuration node with the given initial value.
+ * \param[out] config The function puts the handle to the new node at
+ *                    the address specified by \a config.
+ * \param[in] id The id of the new node.
+ * \param[in] value The initial value of the new node.  May be \c NULL.
+ * \return Zero if successful, otherwise a negative error code.
+ *
+ * This function creates a new node of type #SND_CONFIG_TYPE_STRING. The node
+ * contains with a copy of the string \c value, replacing any character other
+ * than alphanumeric, space, or '-' with the character '_'.
+ *
+ * \par Errors:
+ * <dl>
+ * <dt>-ENOMEM<dd>Out of memory.
+ * </dl>
+ *
+ * \par Conforming to:
+ * LSB 3.2
+ */
 int snd_config_imake_safe_string(snd_config_t **config, const char *id, const char *value)
 {
 	int err;
@@ -3894,7 +3918,6 @@ int snd_config_search_alias_hooks(snd_config_t *config,
 #define ALSA_CONFIG_PATH_VAR "ALSA_CONFIG_PATH"
 
 /**
- * \ingroup Config
  * \brief Configuration top-level node (the global configuration).
  *
  * This variable contains a handle to the top-level configuration node,
@@ -4295,7 +4318,7 @@ SND_DLSYM_BUILD_VERSION(snd_config_hook_load, SND_CONFIG_DLSYM_VERSION_HOOK);
 int snd_determine_driver(int card, char **driver);
 #endif
 
-snd_config_t *_snd_config_hook_private_data(int card, const char *driver)
+static snd_config_t *_snd_config_hook_private_data(int card, const char *driver)
 {
 	snd_config_t *private_data, *v;
 	int err;
@@ -5810,6 +5833,7 @@ static void _snd_config_end(void)
 }
 #endif
 
+#ifndef DOC_HIDDEN
 size_t page_size(void)
 {
 	long s = sysconf(_SC_PAGE_SIZE);
@@ -5845,3 +5869,4 @@ size_t page_ptr(size_t object_offset, size_t object_size, size_t *offset, size_t
 	*offset = object_offset;
 	return r;
 }
+#endif /* DOC_HIDDEN */

--- a/src/conf.c
+++ b/src/conf.c
@@ -2055,7 +2055,7 @@ int snd_config_load(snd_config_t *config, snd_input_t *in)
 
 /**
  * \brief Loads a configuration tree from a string.
- * \param[out] The function puts the handle to the configuration
+ * \param[out] config The function puts the handle to the configuration
  *	       node loaded from the file(s) at the address specified
  *             by \a config.
  * \param[in] s String with the ASCII configuration
@@ -2260,9 +2260,9 @@ static int _snd_config_array_merge(snd_config_t *dst, snd_config_t *src, int ind
 
 /**
  * \brief In-place merge of two config handles
- * \param dst[out] Config handle for the merged contents
- * \param src[in] Config handle to merge into dst (may be NULL)
- * \param override[in] Override flag
+ * \param[out] dst Config handle for the merged contents
+ * \param[in] src Config handle to merge into dst (may be NULL)
+ * \param[in] override Override flag
  * \return Zero if successful, otherwise a negative error code.
  *
  * This function merges all fields from the source compound to the destination compound.

--- a/src/confeval.c
+++ b/src/confeval.c
@@ -38,7 +38,9 @@
 #include <limits.h>
 #include "local.h"
 
+#ifndef DOC_HIDDEN
 typedef long long value_type_t;
+#endif /* DOC_HIDDEN */
 
 static const char *_find_end_of_expression(const char *s, char begin, char end)
 {
@@ -119,6 +121,7 @@ static int _to_integer(value_type_t *val, snd_config_t *c)
 	return err;
 }
 
+#ifndef DOC_HIDDEN
 int _snd_eval_string(snd_config_t **dst, const char *s,
 		     snd_config_expand_fcn_t fcn, void *private_data)
 {
@@ -244,6 +247,7 @@ int _snd_eval_string(snd_config_t **dst, const char *s,
 	else
 		return snd_config_imake_integer(dst, NULL, left);
 }
+#endif /* DOC_HIDDEN */
 
 /**
  * \brief Evaluate an math expression in the string
@@ -251,7 +255,7 @@ int _snd_eval_string(snd_config_t **dst, const char *s,
  *                 node at the address specified by \a dst.
  * \param[in] s A string to evaluate
  * \param[in] fcn A function to get the variable contents
- * \param[in] private_value A private value for the variable contents function
+ * \param[in] private_data A private value for the variable contents function
  * \return 0 if successful, otherwise a negative error code.
  */
 int snd_config_evaluate_string(snd_config_t **dst, const char *s,

--- a/src/confmisc.c
+++ b/src/confmisc.c
@@ -645,7 +645,7 @@ static int string_from_integer(char **dst, long v)
 }
 #endif
 
-int _snd_func_private_data(snd_config_t **dst, snd_config_t *src,
+static int _snd_func_private_data(snd_config_t **dst, snd_config_t *src,
 			   snd_config_t **private_data, const char *id)
 {
 	int err;

--- a/src/confmisc.c
+++ b/src/confmisc.c
@@ -1031,6 +1031,14 @@ int snd_func_card_name(snd_config_t **dst, snd_config_t *root,
 SND_DLSYM_BUILD_VERSION(snd_func_card_name, SND_CONFIG_DLSYM_VERSION_EVALUATE);
 #endif
 
+#ifdef DOXYGEN
+/* For consistency with the PCM Interface module, include documentation even
+ * when PCM module is not included in the build. */ 
+#ifndef BUILD_PCM
+#define BUILD_PCM
+#endif
+#endif /* DOXYGEN */
+
 #ifdef BUILD_PCM
 
 /**

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -428,6 +428,7 @@ int snd_ctl_elem_info(snd_ctl_t *ctl, snd_ctl_elem_info_t *info)
 	return ctl->ops->element_info(ctl, info);
 }
 
+#ifndef DOC_HIDDEN
 #if 0 /* deprecated */
 static bool validate_element_member_dimension(snd_ctl_elem_info_t *info)
 {
@@ -502,6 +503,8 @@ int __snd_ctl_add_elem_set(snd_ctl_t *ctl, snd_ctl_elem_info_t *info,
 
 	return ctl->ops->element_add(ctl, info);
 }
+
+#endif /* DOC_HIDDEN */
 
 /**
  * \brief Create and add some user-defined control elements of integer type.

--- a/src/control/control_ext.c
+++ b/src/control/control_ext.c
@@ -622,7 +622,7 @@ The rest fields are filled by #snd_ctl_ext_create().  The handle field
 is the resultant PCM handle.  The others are the current status of the
 PCM.
 
-\section ctl_ext_impl Callback Functions of External Control Plugins
+\section ctl_ext_impl_cb Callback Functions of External Control Plugins
 
 The callback functions in #snd_ctl_ext_callback_t define the real
 behavior of the driver.  There are many callbacks but many of them are optional. 

--- a/src/control/control_hw.c
+++ b/src/control/control_hw.c
@@ -40,11 +40,12 @@
 const char *_snd_module_control_hw = "";
 #endif
 
+#ifndef DOC_HIDDEN
+
 #ifndef F_SETSIG
 #define F_SETSIG 10
 #endif
 
-#ifndef DOC_HIDDEN
 #define SNDRV_FILE_CONTROL	ALSA_DEVICE_DIRECTORY "controlC%i"
 #define SNDRV_CTL_VERSION_MAX	SNDRV_PROTOCOL_VERSION(2, 0, 4)
 

--- a/src/control/control_remap.c
+++ b/src/control/control_remap.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include "control_local.h"
 
+#ifndef DOC_HIDDEN
 #if 0
 #define REMAP_DEBUG 1
 #define debug(format, args...) fprintf(stderr, format, ##args)
@@ -48,6 +49,7 @@
 #endif
 
 #define EREMAPNOTFOUND (888899)
+#endif /* DOC_HIDDEN */
 
 #ifndef PIC
 /* entry for static linking */
@@ -379,10 +381,12 @@ static int snd_ctl_remap_elem_list(snd_ctl_t *ctl, snd_ctl_elem_list_t *list)
 	return 0;
 }
 
+#ifndef DOC_HIDDEN
 #define ACCESS_BITS(bits) \
 	(bits & (SNDRV_CTL_ELEM_ACCESS_READWRITE|\
 		 SNDRV_CTL_ELEM_ACCESS_VOLATILE|\
 		 SNDRV_CTL_ELEM_ACCESS_TLV_READWRITE))
+#endif /* DOC_HIDDEN */
 
 static int remap_map_elem_info(snd_ctl_remap_t *priv, snd_ctl_elem_info_t *info)
 {
@@ -1141,6 +1145,7 @@ static int parse_map(snd_ctl_remap_t *priv, snd_config_t *conf)
  * \param name Name of control device
  * \param remap Remap configuration
  * \param map Map configuration
+ * \param child child configuration root
  * \param mode Control handle mode
  * \retval zero on success otherwise a negative error code
  * \warning Using of this function might be dangerous in the sense
@@ -1326,4 +1331,6 @@ int _snd_ctl_remap_open(snd_ctl_t **handlep, char *name, snd_config_t *root, snd
 		snd_ctl_close(cctl);
 	return err;
 }
+#ifndef DOC_HIDDEN
 SND_DLSYM_BUILD_VERSION(_snd_ctl_remap_open, SND_CONTROL_DLSYM_VERSION);
+#endif

--- a/src/control/namehint.c
+++ b/src/control/namehint.c
@@ -1,5 +1,6 @@
 /**
  * \file control/namehint.c
+ * \ingroup Configuration
  * \brief Give device name hints
  * \author Jaroslav Kysela <perex@perex.cz>
  * \date 2006

--- a/src/dlmisc.c
+++ b/src/dlmisc.c
@@ -170,8 +170,10 @@ EXPORT_SYMBOL void *INTERNAL(snd_dlopen_old)(const char *name, int mode)
 }
 #endif
 
+#ifndef DOC_HIDDEN
 use_symbol_version(__snd_dlopen_old, snd_dlopen, ALSA_0.9);
 use_default_symbol_version(__snd_dlopen, snd_dlopen, ALSA_1.1.6);
+#endif /* DOC_HIDDEN */
 
 /**
  * \brief Closes a dynamic library - ALSA wrapper for \c dlclose.

--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -223,7 +223,7 @@ There are two methods to transfer samples in application. The first method
 is the standard read / write one. The second method, uses the direct audio
 buffer to communicate with the device while ALSA library manages this space
 itself. You can find examples of all communication schemes for playback
-in \ref example_test_pcm "Sine-wave generator example". To complete the
+in \link example_test_pcm Sine-wave generator example \endlink. To complete the
 list, we should note that #snd_pcm_wait() function contains
 embedded poll waiting implementation.
 
@@ -632,30 +632,39 @@ The null device is null plugin. This device has not any arguments.
 The full featured examples with cross-links can be found in Examples section
 (see top of page):
 
-\anchor example_test_pcm
 \par Sine-wave generator
 \par
-alsa-lib/test/pcm.c example shows various transfer methods for the playback direction.
+\link example_test_pcm alsa-lib/test/pcm.c \endlink
+example shows various transfer methods for the playback direction.
 
 \par Minimalistic PCM playback code
 \par
-alsa-lib/test/pcm_min.c example shows the minimal code to produce a sound.
+\link example_test_minimal alsa-lib/test/pcm_min.c \endlink
+example shows the minimal code to produce a sound.
 
 \par Latency measuring tool
 \par
-alsa-lib/test/latency.c example shows the measuring of minimal latency between capture and
+\link example_test_latency alsa-lib/test/latency.c \endlink
+example shows the measuring of minimal latency between capture and
 playback devices.
 
 */
 
 /**
 \example ../../test/pcm.c
+\anchor example_test_pcm
+Shows various transfer methods for the playback direction.
 */
 /**
 \example ../../test/pcm_min.c
+\anchor example_test_minimal
+Shows the minimal code to produce a sound.
 */
 /**
 \example ../../test/latency.c
+\anchor example_test_latency
+Shows the measuring of minimal latency between capture and
+playback devices.
 */
 
 #include <stdio.h>
@@ -7431,7 +7440,7 @@ int __snd_pcm_mmap_begin(snd_pcm_t *pcm, const snd_pcm_channel_area_t **areas,
  _skip:
 \endcode
  *
- * Look to the \ref example_test_pcm "Sine-wave generator" example
+ * Look to the \link example_test_pcm Sine-wave generator \endlink example
  * for more details about the generate_sine function.
  *
  * The function is thread-safe when built with the proper option.

--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -2234,7 +2234,7 @@ const char *snd_pcm_tstamp_mode_name(const snd_pcm_tstamp_t mode)
 
 /**
  * \brief get name of PCM tstamp type setting
- * \param mode PCM tstamp type
+ * \param type PCM tstamp type
  * \return ascii name of PCM tstamp type setting
  */
 const char *snd_pcm_tstamp_type_name(snd_pcm_tstamp_type_t type)
@@ -3439,10 +3439,10 @@ int snd_pcm_areas_copy(const snd_pcm_channel_area_t *dst_areas, snd_pcm_uframes_
 
 /**
  * \brief Copy one or more areas
- * \param dst_areas destination areas specification (one for each channel)
+ * \param dst_channels destination areas specification (one for each channel)
  * \param dst_offset offset in frames inside destination area
  * \param dst_size size in frames of the destination buffer
- * \param src_areas source areas specification (one for each channel)
+ * \param src_channels source areas specification (one for each channel)
  * \param src_offset offset in frames inside source area
  * \param dst_size size in frames of the source buffer
  * \param channels channels count
@@ -7022,7 +7022,7 @@ void snd_pcm_status_get_driver_htstamp(const snd_pcm_status_t *obj, snd_htimesta
 /**
  * \brief Get audio_tstamp_report from a PCM status container
  * \param obj pointer to #snd_pcm_status_t
- * \param ptr Pointer to returned report (valid fields are accuracy and type)
+ * \param audio_tstamp_report Pointer to returned report (valid fields are accuracy and type)
  */
 void snd_pcm_status_get_audio_htstamp_report(const snd_pcm_status_t *obj,
 					     snd_pcm_audio_tstamp_report_t *audio_tstamp_report)
@@ -7036,7 +7036,7 @@ void snd_pcm_status_get_audio_htstamp_report(const snd_pcm_status_t *obj,
 /**
  * \brief set audio_tstamp_config from a PCM status container
  * \param obj pointer to #snd_pcm_status_t
- * \param ptr Pointer to config (valid fields are type and report_analog_delay)
+ * \param audio_tstamp_config Pointer to config (valid fields are type and report_analog_delay)
  */
 void snd_pcm_status_set_audio_htstamp_config(snd_pcm_status_t *obj,
 					     snd_pcm_audio_tstamp_config_t *audio_tstamp_config)

--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -3444,7 +3444,7 @@ int snd_pcm_areas_copy(const snd_pcm_channel_area_t *dst_areas, snd_pcm_uframes_
  * \param dst_size size in frames of the destination buffer
  * \param src_channels source areas specification (one for each channel)
  * \param src_offset offset in frames inside source area
- * \param dst_size size in frames of the source buffer
+ * \param src_size size in frames of the source buffer
  * \param channels channels count
  * \param frames frames to copy
  * \param format PCM sample format
@@ -7022,7 +7022,7 @@ void snd_pcm_status_get_driver_htstamp(const snd_pcm_status_t *obj, snd_htimesta
 /**
  * \brief Get audio_tstamp_report from a PCM status container
  * \param obj pointer to #snd_pcm_status_t
- * \param audio_tstamp_report Pointer to returned report (valid fields are accuracy and type)
+ * \param audio_tstamp_report Pointer to returned report
  */
 void snd_pcm_status_get_audio_htstamp_report(const snd_pcm_status_t *obj,
 					     snd_pcm_audio_tstamp_report_t *audio_tstamp_report)
@@ -7036,7 +7036,7 @@ void snd_pcm_status_get_audio_htstamp_report(const snd_pcm_status_t *obj,
 /**
  * \brief set audio_tstamp_config from a PCM status container
  * \param obj pointer to #snd_pcm_status_t
- * \param audio_tstamp_config Pointer to config (valid fields are type and report_analog_delay)
+ * \param audio_tstamp_config Pointer to config (valid fields are type_requested and report_delay)
  */
 void snd_pcm_status_set_audio_htstamp_config(snd_pcm_status_t *obj,
 					     snd_pcm_audio_tstamp_config_t *audio_tstamp_config)

--- a/src/pcm/pcm_extplug.c
+++ b/src/pcm/pcm_extplug.c
@@ -650,8 +650,8 @@ parameter linked #snd_pcm_extplug_set_param_link() can be used for the
 corresponding parameter. For example if the extplug does not support channel nor
 format conversion the supported client parameters can be limited with
 snd_pcm_extplug_set_param_*() and afterwards
-#snd_pcm_extplug_set_param_link(ext, SND_PCM_EXTPLUG_HW_FORMAT, 1) and
-#snd_pcm_extplug_set_param_link(ext, SND_PCM_EXTPLUG_HW_CHANNELS, 1) should be
+snd_pcm_extplug_set_param_link(ext, SND_PCM_EXTPLUG_HW_FORMAT, 1) and
+snd_pcm_extplug_set_param_link(ext, SND_PCM_EXTPLUG_HW_CHANNELS, 1) should be
 called to keep the client and slave parameters the same.
 */
 

--- a/src/pcm/pcm_meter.c
+++ b/src/pcm/pcm_meter.c
@@ -34,9 +34,11 @@
 #include "pcm_local.h"
 #include "pcm_plugin.h"
 
+#ifndef DOC_HIDDEN
 #define atomic_read(ptr)    __atomic_load_n(ptr, __ATOMIC_SEQ_CST )
 #define atomic_add(ptr, n)  __atomic_add_fetch(ptr, n, __ATOMIC_SEQ_CST)
 #define atomic_dec(ptr)     __atomic_sub_fetch(ptr, 1, __ATOMIC_SEQ_CST)
+#endif
 
 #ifndef PIC
 /* entry for static linking */

--- a/src/pcm/pcm_route.c
+++ b/src/pcm/pcm_route.c
@@ -766,7 +766,9 @@ static int strtochannel(const char *id, snd_pcm_chmap_t *chmap,
 	}
 }
 
+#ifndef DOC_HIDDEN
 #define MAX_CHMAP_CHANNELS 256
+#endif
 
 static int determine_chmap(snd_config_t *tt, snd_pcm_chmap_t **tt_chmap)
 {

--- a/src/rawmidi/rawmidi.c
+++ b/src/rawmidi/rawmidi.c
@@ -132,7 +132,7 @@ The timestamping is available only on input streams.
 The full featured examples with cross-links:
 
 \par Simple input/output test program
-\ref example_test_rawmidi "example code"
+\link example_test_rawmidi example code \endlink
 \par
 This example shows open and read/write rawmidi operations.
 
@@ -141,6 +141,7 @@ This example shows open and read/write rawmidi operations.
 /**
  * \example ../test/rawmidi.c
  * \anchor example_test_rawmidi
+ * Shows open and read/write rawmidi operations.
  */
  
 #include <stdio.h>

--- a/src/rawmidi/ump.c
+++ b/src/rawmidi/ump.c
@@ -674,6 +674,7 @@ const char *snd_ump_block_info_get_name(const snd_ump_block_info_t *info)
 
 /**
  * \brief get UMP block information
+ * \param ump UMP handle
  * \param info pointer to a snd_ump_block_info_t structure
  * \return 0 on success otherwise a negative error code
  *

--- a/src/rawmidi/ump.c
+++ b/src/rawmidi/ump.c
@@ -315,7 +315,7 @@ size_t snd_ump_endpoint_info_sizeof(void)
 
 /**
  * \brief allocate the snd_ump_endpoint_info_t structure
- * \param ptr returned pointer
+ * \param info returned pointer
  * \return 0 on success otherwise a negative error code if fails
  *
  * Allocates a new snd_rawmidi_status_t structure using the standard
@@ -331,7 +331,7 @@ int snd_ump_endpoint_info_malloc(snd_ump_endpoint_info_t **info)
 
 /**
  * \brief frees the snd_ump_endpoint_info_t structure
- * \param status pointer to the snd_ump_endpoint_info_t structure to free
+ * \param info pointer to the snd_ump_endpoint_info_t structure to free
  *
  * Frees the given snd_ump_endpoint_info_t structure using the standard
  * free C library function.
@@ -504,7 +504,7 @@ size_t snd_ump_block_info_sizeof(void)
 
 /**
  * \brief allocate the snd_ump_block_info_t structure
- * \param ptr returned pointer
+ * \param info returned pointer
  * \return 0 on success otherwise a negative error code if fails
  *
  * Allocates a new snd_ump_block_info_t structure using the standard
@@ -520,7 +520,7 @@ int snd_ump_block_info_malloc(snd_ump_block_info_t **info)
 
 /**
  * \brief frees the snd_ump_block_info_t structure
- * \param status pointer to the snd_ump_block_info_t structure to free
+ * \param info pointer to the snd_ump_block_info_t structure to free
  *
  * Frees the given snd_ump_block_info_t structure using the standard
  * free C library function.

--- a/src/rawmidi/ump_local.h
+++ b/src/rawmidi/ump_local.h
@@ -3,8 +3,10 @@
 #include "ump.h"
 #include "ump_msg.h"
 
+#ifndef DOC_HIDDEN
 struct _snd_ump {
 	snd_rawmidi_t *rawmidi;
 	unsigned int flags;
 	int is_input;
 };
+#endif /* DOC_HIDDEN */

--- a/src/seq/seq.c
+++ b/src/seq/seq.c
@@ -1763,7 +1763,9 @@ int snd_seq_client_info_get_ump_group_enabled(const snd_seq_client_info_t *info,
 	return !(info->group_filter & (1U << group));
 }
 
+#ifndef DOC_HIDDEN
 #define UMP_GROUPLESS_FILTER	(1U << 0)
+#endif /* DOC_HIDDEN */
 
 /**
  * \brief Get the UMP groupless message handling status

--- a/src/shmarea.c
+++ b/src/shmarea.c
@@ -18,6 +18,16 @@
  *
  */
 
+/**
+ * \file shmarea.c
+ * \ingroup Global
+ * \brief shared memory helpers
+ * \author Jaroslav Kysela <perex@perex.cz>
+ * \date 2001
+ *
+ * Shared memory helpers
+ */
+
 #include "config.h"
 
 /* These funcs are only used by pcm_mmap when sys/shm.h is available. */
@@ -102,6 +112,7 @@ int snd_shm_area_destroy(struct snd_shm_area *area)
 	return 0;
 }
 
+#ifndef DOC_HIDDEN
 void snd_shm_area_destructor(void) __attribute__ ((destructor));
 
 void snd_shm_area_destructor(void)
@@ -114,5 +125,6 @@ void snd_shm_area_destructor(void)
 		shmdt(area->ptr);
 	}
 }
+#endif /* DOC_HIDDEN */
 
 #endif

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -56,7 +56,7 @@ Events are read via snd_timer_read() function.
 The full featured examples with cross-links:
 
 \par Simple timer test program
-\ref example_test_timer "example code"
+\link example_test_timer example code \endlink
 \par
 This example shows opening a timer device and reading of timer events.
 

--- a/src/topology/ctl.c
+++ b/src/topology/ctl.c
@@ -20,12 +20,14 @@
 #include "list.h"
 #include "tplg_local.h"
 
+#ifndef DOC_HIDDEN
 #define ENUM_VAL_SIZE 	(SNDRV_CTL_ELEM_ID_NAME_MAXLEN >> 2)
 
 struct ctl_access_elem {
 	const char *name;
 	unsigned int value;
 };
+#endif /* DOC_HIDDEN */
 
 /* CTL access strings and codes */
 /* place the multi-bit values on top - like read_write - for save */

--- a/src/topology/data.c
+++ b/src/topology/data.c
@@ -713,11 +713,13 @@ static int build_tuples(snd_tplg_t *tplg, struct tplg_elem *elem)
 	return 0;
 }
 
+#ifndef DOC_HIDDEN
 struct tuple_type {
 	unsigned int type;
 	const char *name;
 	unsigned int size;
 };
+#endif /* DOC_HIDDEN */
 
 static struct tuple_type tuple_types[] = {
 	{

--- a/src/topology/elem.c
+++ b/src/topology/elem.c
@@ -482,10 +482,12 @@ struct tplg_elem* tplg_elem_new_common(snd_tplg_t *tplg,
 	return elem;
 }
 
+#ifndef DOC_HIDDEN
 struct tplg_alloc {
 	struct list_head list;
 	void *data[0];
 };
+#endif /* DOC_HIDDEN */
 
 void *tplg_calloc(struct list_head *heap, size_t size)
 {

--- a/src/topology/pcm.c
+++ b/src/topology/pcm.c
@@ -1365,10 +1365,12 @@ int tplg_save_cc(snd_tplg_t *tplg ATTRIBUTE_UNUSED,
 	return err;
 }
 
+#ifndef DOC_HIDDEN
 struct audio_hw_format {
 	unsigned int type;
 	const char *name;
 };
+#endif /* DOC_HIDDEN */
 
 static struct audio_hw_format audio_hw_formats[] = {
 	{

--- a/src/ucm/main.c
+++ b/src/ucm/main.c
@@ -2791,7 +2791,7 @@ int snd_use_case_set(snd_use_case_mgr_t *uc_mgr,
 
 /**
  * \brief Parse control element identifier
- * \param elem_id Element identifier
+ * \param dst Element identifier
  * \param ucm_id Use case identifier
  * \param value String value to be parsed
  * \return Zero if success, otherwise a negative error code

--- a/src/ucm/main.c
+++ b/src/ucm/main.c
@@ -1505,12 +1505,6 @@ skip:
 	return end + 3;
 }
 
-/**
- * \brief Init sound card use case manager.
- * \param uc_mgr Returned use case manager pointer
- * \param card_name name of card to open
- * \return zero on success, otherwise a negative error code
- */
 int snd_use_case_mgr_open(snd_use_case_mgr_t **uc_mgr,
 			  const char *card_name)
 {
@@ -1577,11 +1571,6 @@ _err:
 	return err;
 }
 
-/**
- * \brief Reload and reparse all use case files.
- * \param uc_mgr Use case manager
- * \return zero on success, otherwise a negative error code
- */
 int snd_use_case_mgr_reload(snd_use_case_mgr_t *uc_mgr)
 {
 	int err;
@@ -1606,11 +1595,6 @@ int snd_use_case_mgr_reload(snd_use_case_mgr_t *uc_mgr)
 	return err;
 }
 
-/**
- * \brief Close use case manager.
- * \param uc_mgr Use case manager
- * \return zero on success, otherwise a negative error code
- */
 int snd_use_case_mgr_close(snd_use_case_mgr_t *uc_mgr)
 {
 	uc_mgr_card_close(uc_mgr);
@@ -1659,11 +1643,6 @@ static int dismantle_use_case(snd_use_case_mgr_t *uc_mgr)
 	return err;
 }
 
-/**
- * \brief Reset sound card controls to default values.
- * \param uc_mgr Use case manager
- * \return zero on success, otherwise a negative error code
- */
 int snd_use_case_mgr_reset(snd_use_case_mgr_t *uc_mgr)
 {
 	int err;
@@ -2095,13 +2074,6 @@ static int get_enabled_modifier_list(snd_use_case_mgr_t *uc_mgr,
 			name);
 }
 
-/**
- * \brief Obtain a list of entries
- * \param uc_mgr Use case manager (may be NULL - card list)
- * \param identifier (may be NULL - card list)
- * \param list Returned allocated list
- * \return Number of list entries if success, otherwise a negative error code
- */
 int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
 			  const char *identifier,
 			  const char **list[])
@@ -2312,16 +2284,6 @@ static int get_alibpref(snd_use_case_mgr_t *uc_mgr, char **str)
 	return 0;
 }
 
-/**
- * \brief Get current - string
- * \param uc_mgr Use case manager
- * \param identifier 
- * \param value Value pointer
- * \return Zero if success, otherwise a negative error code
- *
- * Note: String is dynamically allocated, use free() to
- * deallocate this string.
- */      
 int snd_use_case_get(snd_use_case_mgr_t *uc_mgr,
 		     const char *identifier,
 		     const char **value)
@@ -2434,12 +2396,6 @@ int snd_use_case_get(snd_use_case_mgr_t *uc_mgr,
 	; val; /* return value */ \
 })
 
-/**
- * \brief Get current - integer
- * \param uc_mgr Use case manager
- * \param identifier
- * \return Value if success, otherwise a negative error code
- */
 int snd_use_case_geti(snd_use_case_mgr_t *uc_mgr,
 		      const char *identifier,
 		      long *value)
@@ -2732,13 +2688,6 @@ static int switch_modifier(snd_use_case_mgr_t *uc_mgr,
 	return err;
 }
 
-/**
- * \brief Set new
- * \param uc_mgr Use case manager
- * \param identifier
- * \param value Value
- * \return Zero if success, otherwise a negative error code
- */
 int snd_use_case_set(snd_use_case_mgr_t *uc_mgr,
 		     const char *identifier,
 		     const char *value)

--- a/src/ucm/ucm_confdoc.h
+++ b/src/ucm/ucm_confdoc.h
@@ -397,18 +397,18 @@ ${CardDriver}        | ALSA card driver (see snd_ctl_card_info_get_driver())
 ${CardName}          | ALSA card name (see snd_ctl_card_info_get_name())
 ${CardLongName}      | ALSA card long name (see snd_ctl_card_info_get_longname())
 ${CardComponents}    | ALSA card components (see snd_ctl_card_info_get_components())
-${env:<str>}         | Environment variable <str>
-${sys:<str>}         | Contents of sysfs file <str>
-${var:<str>}         | UCM parser variable (set using a _Define_ block)
-${eval:<str>}        | Evaluate expression like *($var+2)/3* [**Syntax 5**]
-${find-card:<str>}   | Find a card - see _Find card substitution_ section
-${find-device:<str>} | Find a device - see _Find device substitution_ section
+${env:\<str\>}         | Environment variable \<str\>
+${sys:\<str\>}         | Contents of sysfs file \<str\>
+${var:\<str\>}         | UCM parser variable (set using a _Define_ block)
+${eval:\<str\>}        | Evaluate expression like *($var+2)/3* [**Syntax 5**]
+${find-card:\<str\>}   | Find a card - see _Find card substitution_ section
+${find-device:\<str\>} | Find a device - see _Find device substitution_ section
 
 #### Special whole string substitution
 
 Substituted string   | Value
 ---------------------|---------------------
-${evali:<str>}       | Evaluate expression like *($var+2)/3* [**Syntax 6**]; target node will be integer; substituted only in the LibraryConfig subtree
+${evali:\<str\>}       | Evaluate expression like *($var+2)/3* [**Syntax 6**]; target node will be integer; substituted only in the LibraryConfig subtree
 
 #### Find card substitution
 

--- a/src/ucm/ucm_subs.c
+++ b/src/ucm/ucm_subs.c
@@ -191,6 +191,7 @@ static char *rval_card_id_by_name(snd_use_case_mgr_t *uc_mgr, const char *id)
 	return strdup(snd_ctl_card_info_get_id(ctl_list->ctl_info));
 }
 
+#ifndef DOC_HIDDEN
 typedef struct lookup_iterate *(*lookup_iter_fcn_t)
 			(snd_use_case_mgr_t *uc_mgr, struct lookup_iterate *iter);
 typedef const char *(*lookup_fcn_t)(void *);
@@ -212,6 +213,7 @@ struct lookup_iterate {
 	struct ctl_list *ctl_list;
 	void *info;
 };
+#endif /* DOC_HIDDEN */
 
 static char *rval_lookup_main(snd_use_case_mgr_t *uc_mgr,
 			      const char *query,


### PR DESCRIPTION
Fixes missing doxygen tags and macros so that now doxygen picks up all of the documentation comments and completes cleanly without any errors or warnings.