### PR TITLE
pcm: Add error handler for `read` that `snd_pcm_share_thread` function calls

### DIFF
--- a/src/pcm/pcm_share.c
+++ b/src/pcm/pcm_share.c
@@ -414,7 +414,12 @@ static void *snd_pcm_share_thread(void *data)
 			Pthread_mutex_lock(&slave->mutex);
 			if (pfd[0].revents & POLLIN) {
 				char buf[1];
-				read(pfd[0].fd, buf, 1);
+				err = read(pfd[0].fd, buf, 1);
+				if (err < 0) {
+					SYSERR("can't read from a pipe");
+					Pthread_mutex_unlock(&slave->mutex);
+					return NULL;
+				}
 			}
 		} else {
 			slave->polling = 0;


### PR DESCRIPTION
Maybe, this error occurs if cannot read from a pipe.

<img width="1364" alt="compile warning" src="https://github.com/alsa-project/alsa-lib/assets/4006693/275e0b6a-ebdf-4cd3-a766-5be1b75d2eb0">
