### PR TITLE
mixer: simple: Support dB TLVs for CTL_SINGLE controls

### DIFF
--- a/src/mixer/simple_none.c
+++ b/src/mixer/simple_none.c
@@ -1155,11 +1155,12 @@ static selem_ctl_t *get_selem_ctl(selem_none_t *s, int dir)
 		c = &s->ctls[CTL_CAPTURE_VOLUME];
 	else
 		return NULL;
-	if (! c->elem) {
+	if (! c->elem)
 		c = &s->ctls[CTL_GLOBAL_VOLUME];
-		if (! c->elem)
-			return NULL;
-	}
+	if (! c->elem)
+		c = &s->ctls[CTL_SINGLE];
+	if (! c->elem)
+		return NULL;
 	if (c->type != SND_CTL_ELEM_TYPE_INTEGER)
 		return NULL;
 	return c;


### PR DESCRIPTION
dB mappings do not work for controls not named "* Volume", since we do not fall back to CTL_SINGLE in get_selem_ctl. Add that branch to make it work.

Fixes dB ranges for e.g. controls named "* Gain".