### PR TITLE
Clang: fix versioned symbol build errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -749,7 +749,7 @@ fi
 
 AC_CONFIG_FILES(Makefile doc/Makefile doc/pictures/Makefile doc/doxygen.cfg \
 		include/Makefile include/sound/Makefile include/sound/uapi/Makefile \
-		src/Versions src/Makefile \
+		src/Versions.in src/Makefile \
 		src/control/Makefile src/mixer/Makefile \
 		src/pcm/Makefile src/pcm/scopes/Makefile \
 		src/rawmidi/Makefile src/timer/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -747,22 +747,24 @@ if test ! -L "$srcdir"/include/alsa ; then
   ln -sf . "$srcdir"/include/alsa
 fi
 
-AC_OUTPUT(Makefile doc/Makefile doc/pictures/Makefile doc/doxygen.cfg \
-	  include/Makefile include/sound/Makefile include/sound/uapi/Makefile \
-	  src/Versions src/Makefile \
-          src/control/Makefile src/mixer/Makefile \
-	  src/pcm/Makefile src/pcm/scopes/Makefile \
-	  src/rawmidi/Makefile src/timer/Makefile \
-          src/hwdep/Makefile src/seq/Makefile src/ucm/Makefile \
-          src/alisp/Makefile src/topology/Makefile \
-	  src/conf/Makefile \
-	  src/conf/cards/Makefile \
-	  src/conf/ctl/Makefile \
-	  src/conf/pcm/Makefile \
-	  modules/Makefile modules/mixer/Makefile modules/mixer/simple/Makefile \
-	  alsalisp/Makefile aserver/Makefile \
-	  test/Makefile test/lsb/Makefile \
-	  utils/Makefile utils/alsa-lib.spec utils/alsa.pc utils/alsa-topology.pc)
+AC_CONFIG_FILES(Makefile doc/Makefile doc/pictures/Makefile doc/doxygen.cfg \
+		include/Makefile include/sound/Makefile include/sound/uapi/Makefile \
+		src/Versions src/Makefile \
+		src/control/Makefile src/mixer/Makefile \
+		src/pcm/Makefile src/pcm/scopes/Makefile \
+		src/rawmidi/Makefile src/timer/Makefile \
+		src/hwdep/Makefile src/seq/Makefile src/ucm/Makefile \
+		src/alisp/Makefile src/topology/Makefile \
+		src/conf/Makefile \
+		src/conf/cards/Makefile \
+		src/conf/ctl/Makefile \
+		src/conf/pcm/Makefile \
+		modules/Makefile modules/mixer/Makefile modules/mixer/simple/Makefile \
+		alsalisp/Makefile aserver/Makefile \
+		test/Makefile test/lsb/Makefile \
+		utils/Makefile utils/alsa-lib.spec utils/alsa.pc utils/alsa-topology.pc)
+
+AC_OUTPUT()
 
 dnl Create asoundlib.h dynamically according to configure options
 echo "Creating asoundlib.h..."

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,11 @@
-EXTRA_DIST=Versions
 COMPATNUM=@LIBTOOL_VERSION_INFO@
 
 if VERSIONED_SYMBOLS
 VSYMS = -Wl,--version-script=Versions
+BUILT_SOURCES = $(top_builddir)/src/Versions
 else
 VSYMS =
+BUILT_SOURCES =
 endif
 
 if SYMBOLIC_FUNCTIONS
@@ -12,6 +13,8 @@ SYMFUNCS = -Wl,-Bsymbolic-functions
 else
 SYMFUNCS =
 endif
+
+VERSION_CPPFLAGS =
 
 lib_LTLIBRARIES = libasound.la
 libasound_la_SOURCES = conf.c confeval.c confmisc.c input.c output.c async.c error.c dlmisc.c socket.c shmarea.c userfile.c names.c
@@ -43,6 +46,9 @@ SUBDIRS += ucm
 libasound_la_LIBADD += ucm/libucm.la
 endif
 if BUILD_ALISP
+if VERSIONED_SYMBOLS
+VERSION_CPPFLAGS += -DHAVE_ALISP_SYMS
+endif
 SUBDIRS += alisp
 libasound_la_LIBADD += alisp/libalisp.la
 endif
@@ -50,6 +56,9 @@ SUBDIRS += conf
 libasound_la_LIBADD += @ALSA_DEPLIBS@
 
 libasound_la_LDFLAGS = -version-info $(COMPATNUM) $(VSYMS) $(SYMFUNCS) $(LDFLAGS_NOUNDEFINED)
+
+$(top_builddir)/src/Versions: $(top_builddir)/src/Versions.in
+	$(COMPILE) -E $(VERSION_CPPFLAGS) -x assembler-with-cpp -o $@ $<
 
 control/libcontrol.la:
 	$(MAKE) -C control libcontrol.la

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,9 @@ SUBDIRS += mixer
 libasound_la_LIBADD += mixer/libmixer.la
 endif
 if BUILD_PCM
+if VERSIONED_SYMBOLS
+VERSION_CPPFLAGS += -DHAVE_PCM_SYMS -DHAVE_TIMER_SYMS
+endif
 SUBDIRS += pcm timer
 libasound_la_LIBADD += pcm/libpcm.la timer/libtimer.la
 endif

--- a/src/Versions.in.in
+++ b/src/Versions.in.in
@@ -118,15 +118,19 @@ ALSA_0.9.3 {
 } ALSA_0.9.0;
 
 ALSA_0.9.5 {
+#ifdef HAVE_ALISP_SYMS
   global:
 
     @SYMBOL_PREFIX@alsa_lisp;
+#endif
 } ALSA_0.9.3;
 
 ALSA_0.9.7 {
+#ifdef HAVE_ALISP_SYMS
   global:
 
     @SYMBOL_PREFIX@alsa_lisp_*;
+#endif
 } ALSA_0.9.5;
 
 ALSA_1.1.6 {

--- a/src/Versions.in.in
+++ b/src/Versions.in.in
@@ -16,6 +16,7 @@ ALSA_0.9 {
 };
 
 ALSA_0.9.0rc4 {
+#ifdef HAVE_PCM_SYMS
   global:
 
     @SYMBOL_PREFIX@snd_pcm_hw_params_get_access;
@@ -42,6 +43,7 @@ ALSA_0.9.0rc4 {
     @SYMBOL_PREFIX@snd_pcm_hw_params_get_rate_max;
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_rate_near;
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_rate_first;
+
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_rate_last;
 
     @SYMBOL_PREFIX@snd_pcm_hw_params_get_period_time;
@@ -85,22 +87,29 @@ ALSA_0.9.0rc4 {
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_tick_time_near;
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_tick_time_first;
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_tick_time_last;
+#endif
 
 } ALSA_0.9;
 
 ALSA_0.9.0rc8 {
+#ifdef HAVE_PCM_SYMS
   global:
 
     @SYMBOL_PREFIX@snd_pcm_forward;
     @SYMBOL_PREFIX@snd_pcm_status_get_trigger_htstamp;
     @SYMBOL_PREFIX@snd_pcm_status_get_htstamp;
+#endif
 
 } ALSA_0.9.0rc4;
 
 ALSA_0.9.0 {
+#if defined HAVE_PCM_SYMS || defined HAVE_TIMER_SYMS
   global:
 
+#if defined HAVE_PCM_SYMS
     @SYMBOL_PREFIX@snd_pcm_type_name;
+#endif
+#ifdef HAVE_TIMER_SYMS
     @SYMBOL_PREFIX@snd_timer_query_info;
     @SYMBOL_PREFIX@snd_timer_query_params;
     @SYMBOL_PREFIX@snd_timer_query_status;
@@ -108,6 +117,8 @@ ALSA_0.9.0 {
     @SYMBOL_PREFIX@snd_timer_params_get_exclusive;
     @SYMBOL_PREFIX@snd_timer_params_set_filter;
     @SYMBOL_PREFIX@snd_timer_params_get_filter;
+#endif
+#endif
 } ALSA_0.9.0rc8;
 
 ALSA_0.9.3 {
@@ -146,11 +157,13 @@ ALSA_1.2.6 {
 } ALSA_1.1.6;
 
 ALSA_1.2.9 {
+#ifdef HAVE_PCM_SYMS
   global:
 
     @SYMBOL_PREFIX@snd_pcm_hw_params_is_perfect_drain;
     @SYMBOL_PREFIX@snd_pcm_hw_params_set_drain_silence;
     @SYMBOL_PREFIX@snd_pcm_hw_params_get_drain_silence;
+#endif
 } ALSA_1.2.6;
 
 ALSA_1.2.10 {

--- a/src/topology/Makefile.am
+++ b/src/topology/Makefile.am
@@ -1,11 +1,5 @@
 COMPATNUM=@LIBTOOL_VERSION_INFO@
 
-if VERSIONED_SYMBOLS
-VSYMS = -Wl,--version-script=../Versions
-else
-VSYMS =
-endif
-
 if SYMBOLIC_FUNCTIONS
 SYMFUNCS = -Wl,-Bsymbolic-functions
 else
@@ -15,7 +9,7 @@ endif
 lib_LTLIBRARIES = libatopology.la
 
 libatopology_la_LIBADD = ../libasound.la
-libatopology_la_LDFLAGS = -version-info $(COMPATNUM) $(VSYMS) $(SYMFUNCS) $(LDFLAGS_NOUNDEFINED)
+libatopology_la_LDFLAGS = -version-info $(COMPATNUM) $(SYMFUNCS) $(LDFLAGS_NOUNDEFINED)
 
 libatopology_la_SOURCES =\
 	parser.c \


### PR DESCRIPTION
When building alsa-lib with the following settings
```
CFLAGS='-O3 -pipe'
CXXFLAGS='-O3 -pipe'
LDFLAGS='-Wl,-O1 -Wl,--as-needed -fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind'
```
the build fails with errors similar to
```
ld.lld: error: version script assignment of 'ALSA_0.9.5' to symbol 'alsa_lisp' failed: symbol not defined
```
This PR corrects that issue and additional issues found while making corrections so alsa-lib will successfully build using clang and ld.lld.