### PR TITLE
topology: correct version script path

### DIFF
--- a/src/topology/Makefile.am
+++ b/src/topology/Makefile.am
@@ -2,7 +2,7 @@ EXTRA_DIST = Versions
 COMPATNUM=@LIBTOOL_VERSION_INFO@
 
 if VERSIONED_SYMBOLS
-VSYMS = -Wl,--version-script=Versions
+VSYMS = -Wl,--version-script=$(srcdir)/Versions
 else
 VSYMS =
 endif


### PR DESCRIPTION
contrary to libasound, version script for libatopology is a regular source file. while it's often the case that $(builddir) and $(srcdir) point to the same directory, they don't always have to. therefore path needs to point explicitly to $(srcdir) for Versions script in topology

Fixes: GH-382
Fixes: dc7da761f3a2 ("topology: separate Versions linker script")