### PR TITLE
conf: aliases: hdmi: Include unconditionally the pcm/hdmi.conf

### DIFF
--- a/src/conf/cards/HDA-Intel.conf
+++ b/src/conf/cards/HDA-Intel.conf
@@ -163,8 +163,6 @@ HDA-Intel.pcm.iec958.0 {
 	hint.device 1
 }
 
-<confdir:pcm/hdmi.conf>
-
 HDA-Intel.pcm.hdmi.common {
 	@args [ CARD DEVICE CTLINDEX AES0 AES1 AES2 AES3 ]
 	@args.CARD {

--- a/src/conf/cards/HdmiLpeAudio.conf
+++ b/src/conf/cards/HdmiLpeAudio.conf
@@ -2,8 +2,6 @@
 # Configuration for the Intel HDMI/DP LPE audio
 #
 
-<confdir:pcm/hdmi.conf>
-
 HdmiLpeAudio.pcm.hdmi.0 {
 	@args [ CARD AES0 AES1 AES2 AES3 ]
 	@args.CARD {

--- a/src/conf/cards/aliases.conf
+++ b/src/conf/cards/aliases.conf
@@ -62,3 +62,4 @@ VC4-HDMI cards.vc4-hdmi
 <confdir:pcm/default.conf>
 <confdir:pcm/dmix.conf>
 <confdir:pcm/dsnoop.conf>
+<confdir:pcm/hdmi.conf>

--- a/src/conf/cards/vc4-hdmi.conf
+++ b/src/conf/cards/vc4-hdmi.conf
@@ -3,8 +3,6 @@
 # subframe conversion
 #
 
-<confdir:pcm/hdmi.conf>
-
 vc4-hdmi.pcm.hdmi.0 {
 	@args [ CARD AES0 AES1 AES2 AES3 ]
 	@args.CARD {


### PR DESCRIPTION
The hdmi.conf contains the high level macro to be used by cards to create the hdmi: device.
Instead of including it in different config files, include it in the main aliases.conf and remove it's inclusion by other config files.

This change is needed to add support for the hdmi: device mapping via UCM.

Suggested-by: Jaroslav Kysela <perex@perex.cz>