### PR TITLE
src/Versions.in.in: Update *_tempo_base name

### DIFF
--- a/src/Versions.in.in
+++ b/src/Versions.in.in
@@ -212,7 +212,7 @@ ALSA_1.2.13 {
     @SYMBOL_PREFIX@snd_seq_create_ump_block;
     @SYMBOL_PREFIX@snd_seq_queue_tempo_get_tempo_base;
     @SYMBOL_PREFIX@snd_seq_queue_tempo_set_tempo_base;
-    @SYMBOL_PREFIX@snd_seq_has_tempo_base;
+    @SYMBOL_PREFIX@snd_seq_has_queue_tempo_base;
     @SYMBOL_PREFIX@snd_seq_port_info_get_ump_is_midi1;
     @SYMBOL_PREFIX@snd_seq_port_info_set_ump_is_midi1;
 #endif


### PR DESCRIPTION
Change @SYMBOL_PREFIX@snd_has_tempo_base to
@SYMBOL_PREFIX@snd_has_queue_tempo_base.

Starting with version 1.2.13, alsa-lib fails to link with ld.lld-19 due to "version script assignment of 'ALSA_1.2.13' to symbol 'snd_seq_has_tempo_base' failed: symbol not defined".

Per commit 769d1db1b0a213a39c7e59c0d1d724e7f45b1ac3 the correct name for the symbol is @SYMBOL_PREFIX@snd_has_queue_tempo_base; therefore, update src/Vesions.in.in to match.

Fixes bug #420
Fixes Gentoo bug 943399 (https://bugs.gentoo.org/943399)