### PR TITLE
headers: make more headers self-contained

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -28,6 +28,11 @@
 #ifndef __ALSA_CONF_H
 #define __ALSA_CONF_H
 
+#include <stddef.h>
+
+#include <alsa/input.h>
+#include <alsa/output.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/control.h
+++ b/include/control.h
@@ -28,6 +28,10 @@
 #ifndef __ALSA_CONTROL_H
 #define __ALSA_CONTROL_H
 
+#include <stddef.h>
+
+#include <alsa/conf.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/error.h
+++ b/include/error.h
@@ -28,6 +28,8 @@
 #ifndef __ALSA_ERROR_H
 #define __ALSA_ERROR_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/hwdep.h
+++ b/include/hwdep.h
@@ -28,6 +28,9 @@
 #ifndef __ALSA_HWDEP_H
 #define __ALSA_HWDEP_H
 
+#include <string.h>
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/input.h
+++ b/include/input.h
@@ -29,6 +29,7 @@
 #define __ALSA_INPUT_H
 
 #include <stdarg.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -28,6 +28,11 @@
 #ifndef __ALSA_MIXER_H
 #define __ALSA_MIXER_H
 
+#include <alsa/control.h>
+#include <alsa/pcm.h>
+
+#include <string.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/output.h
+++ b/include/output.h
@@ -29,6 +29,8 @@
 #define __ALSA_OUTPUT_H
 
 #include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/pcm.h
+++ b/include/pcm.h
@@ -34,6 +34,10 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <string.h>
+
+#include <alsa/global.h>
+#include <alsa/output.h>
 
 /**
  *  \defgroup PCM PCM Interface

--- a/include/pcm_rate.h
+++ b/include/pcm_rate.h
@@ -31,6 +31,10 @@
 #ifndef __ALSA_PCM_RATE_H
 #define __ALSA_PCM_RATE_H
 
+#include <alsa/conf.h>
+#include <alsa/output.h>
+#include <alsa/pcm.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/rawmidi.h
+++ b/include/rawmidi.h
@@ -28,6 +28,13 @@
 #ifndef __ALSA_RAWMIDI_H
 #define __ALSA_RAWMIDI_H
 
+#include <string.h>
+
+#include <sys/types.h>
+
+#include <alsa/conf.h>
+#include <alsa/global.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/seq.h
+++ b/include/seq.h
@@ -31,6 +31,9 @@
 
 #include "ump.h"
 
+#include <alsa/seq_event.h>
+#include <alsa/timer.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/timer.h
+++ b/include/timer.h
@@ -28,6 +28,13 @@
 #ifndef __ALSA_TIMER_H
 #define __ALSA_TIMER_H
 
+#include <string.h>
+
+#include <sys/types.h>
+
+#include <alsa/conf.h>
+#include <alsa/global.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/topology.h
+++ b/include/topology.h
@@ -22,6 +22,7 @@
 #define __ALSA_TOPOLOGY_H
 
 #include <stdint.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/ump_msg.h
+++ b/include/ump_msg.h
@@ -10,6 +10,7 @@
 #define __ALSA_UMP_MSG_H
 
 #include <stdint.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Some IDEs parse headers in isolation to populate their code model. This exposes some missing headers, mainly for alsa internal struct definitions, ssize_t (requiring sys/types.h), size_t (requiring string.h), va_args (requiring stdargs.h) or FILE (requiring stdio.h)

This patch makes the main headers parsable by qtcreator