### PR TITLE
pcm: hw: do not reset tstamp_type in SND_PCM_APPEND mode

### DIFF
--- a/src/pcm/pcm_hw.c
+++ b/src/pcm/pcm_hw.c
@@ -1665,26 +1665,28 @@ int snd_pcm_hw_open_fd(snd_pcm_t **pcmp, const char *name, int fd,
 		}
 	}
 
+	if (!(mode & SND_PCM_APPEND)) {
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
-	if (SNDRV_PROTOCOL_VERSION(2, 0, 9) <= ver) {
-		struct timespec timespec;
-		if (clock_gettime(CLOCK_MONOTONIC, &timespec) == 0) {
-			int on = SNDRV_PCM_TSTAMP_TYPE_MONOTONIC;
-			if (ioctl(fd, SNDRV_PCM_IOCTL_TTSTAMP, &on) < 0) {
+		if (SNDRV_PROTOCOL_VERSION(2, 0, 9) <= ver) {
+			struct timespec timespec;
+			if (clock_gettime(CLOCK_MONOTONIC, &timespec) == 0) {
+				int on = SNDRV_PCM_TSTAMP_TYPE_MONOTONIC;
+				if (ioctl(fd, SNDRV_PCM_IOCTL_TTSTAMP, &on) < 0) {
+					ret = -errno;
+					SNDMSG("TTSTAMP failed");
+					return ret;
+				}
+				tstamp_type = SND_PCM_TSTAMP_TYPE_MONOTONIC;
+			}
+		} else
+#endif
+		if (SNDRV_PROTOCOL_VERSION(2, 0, 5) <= ver) {
+			int on = 1;
+			if (ioctl(fd, SNDRV_PCM_IOCTL_TSTAMP, &on) < 0) {
 				ret = -errno;
-				SNDMSG("TTSTAMP failed");
+				SNDMSG("TSTAMP failed");
 				return ret;
 			}
-			tstamp_type = SND_PCM_TSTAMP_TYPE_MONOTONIC;
-		}
-	} else
-#endif
-	  if (SNDRV_PROTOCOL_VERSION(2, 0, 5) <= ver) {
-		int on = 1;
-		if (ioctl(fd, SNDRV_PCM_IOCTL_TSTAMP, &on) < 0) {
-			ret = -errno;
-			SNDMSG("TSTAMP failed");
-			return ret;
 		}
 	}
 	


### PR DESCRIPTION
When the first client of plugins such as dshare open the hw device they set a default tstamp_type in snd_pcm_direct_initialize_slave based on tstamp_type from the config file. But when subsequent clients open the same plugin the snd_pcm_hw_open_fd function clobbers this default.