### PR TITLE
test: update midifile library to ANSI C

### DIFF
--- a/test/midifile.c
+++ b/test/midifile.c
@@ -79,34 +79,34 @@
 /* public stuff */
 
 /* Functions to be called while processing the MIDI file. */
-int (*Mf_getc) () = NULLFUNC;
-void (*Mf_error) () = NULLFUNC;
-void (*Mf_header) () = NULLFUNC;
-void (*Mf_trackstart) () = NULLFUNC;
-void (*Mf_trackend) () = NULLFUNC;
-void (*Mf_noteon) () = NULLFUNC;
-void (*Mf_noteoff) () = NULLFUNC;
-void (*Mf_pressure) () = NULLFUNC;
-void (*Mf_parameter) () = NULLFUNC;
-void (*Mf_pitchbend) () = NULLFUNC;
-void (*Mf_program) () = NULLFUNC;
-void (*Mf_chanpressure) () = NULLFUNC;
-void (*Mf_sysex) () = NULLFUNC;
-void (*Mf_arbitrary) () = NULLFUNC;
-void (*Mf_metamisc) () = NULLFUNC;
-void (*Mf_seqnum) () = NULLFUNC;
-void (*Mf_eot) () = NULLFUNC;
-void (*Mf_smpte) () = NULLFUNC;
-void (*Mf_tempo) () = NULLFUNC;
-void (*Mf_timesig) () = NULLFUNC;
-void (*Mf_keysig) () = NULLFUNC;
-void (*Mf_seqspecific) () = NULLFUNC;
-void (*Mf_text) () = NULLFUNC;
+int (*Mf_getc) (void) = NULLFUNC;
+void (*Mf_error) (char *s) = NULLFUNC;
+void (*Mf_header) (int format, int ntrks, int division) = NULLFUNC;
+void (*Mf_trackstart) (void) = NULLFUNC;
+void (*Mf_trackend) (void) = NULLFUNC;
+void (*Mf_noteon) (int chan, int c1, int c2) = NULLFUNC;
+void (*Mf_noteoff) (int chan, int c1, int c2) = NULLFUNC;
+void (*Mf_pressure) (int chan, int c1, int c2) = NULLFUNC;
+void (*Mf_parameter) (int chan, int c1, int c2) = NULLFUNC;
+void (*Mf_pitchbend) (int chan, int c1, int c2) = NULLFUNC;
+void (*Mf_program) (int chan, int c1) = NULLFUNC;
+void (*Mf_chanpressure) (int chan, int c1) = NULLFUNC;
+void (*Mf_sysex) (int len, char *msg) = NULLFUNC;
+void (*Mf_arbitrary) (int len, char *msg) = NULLFUNC;
+void (*Mf_metamisc) (int type, int len, char *msg) = NULLFUNC;
+void (*Mf_seqnum) (int num) = NULLFUNC;
+void (*Mf_eot) (void) = NULLFUNC;
+void (*Mf_smpte) (char m0, char m1, char m2, char m3, char m4) = NULLFUNC;
+void (*Mf_tempo) (long tempo) = NULLFUNC;
+void (*Mf_timesig) (char m0, char m1, char m2, char m3) = NULLFUNC;
+void (*Mf_keysig) (char m0, char m1) = NULLFUNC;
+void (*Mf_seqspecific) (int len, char *msg) = NULLFUNC;
+void (*Mf_text) (int type, int len, char *msg) = NULLFUNC;
 
 /* Functions to implement in order to write a MIDI file */
-int (*Mf_putc) () = NULLFUNC;
-int (*Mf_writetrack) () = NULLFUNC;
-int (*Mf_writetempotrack) () = NULLFUNC;
+int (*Mf_putc) (unsigned char c) = NULLFUNC;
+int (*Mf_writetrack) (int track) = NULLFUNC;
+int (*Mf_writetempotrack) (void) = NULLFUNC;
 
 int Mf_nomerge = 0;		/* 1 => continue'ed system exclusives are */
  /* not collapsed. */
@@ -132,29 +132,34 @@ static int tempo_history_count = 0;
 static long Mf_toberead = 0L;
 static long Mf_numbyteswritten = 0L;
 
-static long readvarinum ();
-static long read32bit ();
-static long to32bit ();
-static int read16bit ();
-static int to16bit ();
-static char *msg ();
-static void readheader ();
-static int readtrack ();
-static void badbyte ();
-static void metaevent ();
-static void sysex ();
-static void chanmessage ();
-static void msginit ();
-static int msgleng ();
-static void msgadd ();
-static void biggermsg ();
-static int eputc ();
+static long readvarinum (void);
+static long read32bit (void);
+static long to32bit (int, int, int, int);
+static int read16bit (void);
+static int to16bit (int, int);
+static char *msg (void);
+static void readheader (void);
+static int readtrack (void);
+static void badbyte (int);
+static void metaevent (int);
+static void sysex (void);
+static void chanmessage (int, int, int);
+static void msginit (void);
+static int msgleng (void);
+static void msgadd (int);
+static void biggermsg (void);
+static int eputc (unsigned char);
 
 double mf_ticks2sec (unsigned long ticks, int division, unsigned long tempo);
-int mf_write_meta_event ();
-void mf_write_tempo ();
-void mf_write_seqnum ();
-void WriteVarLen ();
+void write32bit (unsigned long data);
+void write16bit (int data);
+void mf_write_track_chunk (int which_track, FILE *fp);
+void mf_write_header_chunk (int format, int ntracks, int division);
+int mf_write_meta_event (unsigned long delta_time, unsigned char type,
+	unsigned char *data, unsigned long size);
+void mf_write_tempo (unsigned long delta_time, unsigned long tempo);
+void mf_write_seqnum (unsigned long delta_time, unsigned int seqnum);
+void WriteVarLen (unsigned long value);
 
 #ifdef READ_MODS
 #include "mp_mod.c"
@@ -163,7 +168,7 @@ static int mod_file_flag = 0;
 static int force_exit;
 
 void
-mfread ()
+mfread (void)
 {
   force_exit = 0;
   if (Mf_getc == NULLFUNC)
@@ -181,15 +186,13 @@ mfread ()
 
 /* for backward compatibility with the original lib */
 void
-midifile ()
+midifile (void)
 {
   mfread ();
 }
 
-static
-int 
-readmt (s)			/* read through the "MThd" or "MTrk" header string */
-     char *s;
+static int
+readmt (char *s)		/* read through the "MThd" or "MTrk" header string */
 {
   int n = 0;
   char *p = s;
@@ -211,9 +214,8 @@ readmt (s)			/* read through the "MThd" or "MTrk" header string */
   return (c);
 }
 
-static
-int
-egetc ()			/* read a single character and abort on EOF */
+static int
+egetc (void)		    /* read a single character and abort on EOF */
 {
   int c = (*Mf_getc) ();
 
@@ -225,9 +227,8 @@ egetc ()			/* read a single character and abort on EOF */
   return (c);
 }
 
-static
-void 
-readheader ()			/* read a header chunk */
+static void
+readheader (void)		/* read a header chunk */
 {
   int format, ntrks, division;
 
@@ -280,9 +281,8 @@ readheader ()			/* read a header chunk */
 
 
 /*#define DEBUG_TIMES*/
-static
-unsigned long
-find_tempo()
+static unsigned long
+find_tempo(void)
 {
   int i;
   unsigned long old_tempo = Mf_currtempo;
@@ -307,9 +307,8 @@ printf("[revised_time %lu, new_tempo %lu]\n", revised_time, new_tempo);
   return(new_tempo);
 }
 
-static
-int 
-readtrack ()			/* read a track chunk */
+static int
+readtrack (void)		/* read a track chunk */
 {
   /* This array is indexed by the high half of a status byte.  It's */
   /* value is either the number of bytes needed (1 or 2) for a channel */
@@ -499,10 +498,8 @@ old_f_realtime, delta_secs * 1600.0);
   return (1);
 }
 
-static
-void 
-badbyte (c)
-     int c;
+static void
+badbyte (int c)
 {
   char buff[32];
 
@@ -510,8 +507,7 @@ badbyte (c)
   mferror (buff);
 }
 
-static
-void 
+static void
 metaevent (int type)
 {
   int leng = msgleng ();
@@ -577,19 +573,15 @@ metaevent (int type)
     }
 }
 
-static
-void 
-sysex ()
+static void
+sysex (void)
 {
   if (Mf_sysex)
     (*Mf_sysex) (msgleng (), msg ());
 }
 
-static
-void 
-chanmessage (status, c1, c2)
-     int status;
-     int c1, c2;
+static void
+chanmessage (int status, int c1, int c2)
 {
   int chan = status & 0xf;
 
@@ -635,7 +627,7 @@ chanmessage (status, c1, c2)
 /* number of characters it took. */
 
 static long
-readvarinum ()
+readvarinum (void)
 {
   long value;
   int c;
@@ -668,14 +660,13 @@ to32bit (int c1, int c2, int c3, int c4)
 }
 
 static int
-to16bit (c1, c2)
-     int c1, c2;
+to16bit (int c1, int c2)
 {
   return ((c1 & 0xff) << 8) + (c2 & 0xff);
 }
 
 static long
-read32bit ()
+read32bit (void)
 {
   int c1, c2, c3, c4;
 
@@ -687,7 +678,7 @@ read32bit ()
 }
 
 static int
-read16bit ()
+read16bit (void)
 {
   int c1, c2;
   c1 = egetc ();
@@ -697,8 +688,7 @@ read16bit ()
 
 /* static */
 void
-mferror (s)
-     char *s;
+mferror (char *s)
 {
   if (Mf_error)
     (*Mf_error) (s);
@@ -714,30 +704,26 @@ static char *Msgbuff = NULL;	/* message buffer */
 static int Msgsize = 0;		/* Size of currently allocated Msg */
 static int Msgindex = 0;	/* index of next available location in Msg */
 
-static
-void 
-msginit ()
+static void
+msginit (void)
 {
   Msgindex = 0;
 }
 
 static char *
-msg ()
+msg (void)
 {
   return (Msgbuff);
 }
 
-static
-int 
-msgleng ()
+static int
+msgleng (void)
 {
   return (Msgindex);
 }
 
-static
-void 
-msgadd (c)
-     int c;
+static void
+msgadd (int c)
 {
   /* If necessary, allocate larger message buffer. */
   if (Msgindex >= Msgsize)
@@ -745,11 +731,9 @@ msgadd (c)
   Msgbuff[Msgindex++] = c;
 }
 
-static
-void 
-biggermsg ()
+static void
+biggermsg (void)
 {
-/* 	char *malloc(); */
   char *newmess;
   char *oldmess = Msgbuff;
   int oldleng = Msgsize;
@@ -805,12 +789,9 @@ static int laststatus = 0;
  *             to work with Mf_putc.
  */
 void
-mfwrite (format, ntracks, division, fp)
-     int format, ntracks, division;
-     FILE *fp;
+mfwrite (int format, int ntracks, int division, FILE *fp)
 {
   int i;
-  void mf_write_track_chunk (), mf_write_header_chunk ();
 
   if (Mf_putc == NULLFUNC)
     mferror ("mfmf_write() called without setting Mf_putc");
@@ -837,14 +818,10 @@ mfwrite (format, ntracks, division, fp)
 }
 
 void
-mf_write_track_chunk (which_track, fp)
-     int which_track;
-     FILE *fp;
+mf_write_track_chunk (int which_track, FILE *fp)
 {
   unsigned long trkhdr, trklength;
   long offset, place_marker;
-  void write16bit (), write32bit ();
-
 
   laststatus = 0;
 
@@ -910,11 +887,9 @@ mf_write_track_chunk (which_track, fp)
 
 
 void
-mf_write_header_chunk (format, ntracks, division)
-     int format, ntracks, division;
+mf_write_header_chunk (int format, int ntracks, int division)
 {
   unsigned long ident, length;
-  void write16bit (), write32bit ();
 
   ident = MThd;			/* Head chunk identifier                    */
   length = 6;			/* Chunk length                             */
@@ -948,11 +923,8 @@ mf_write_header_chunk (format, ntracks, division)
  * size - The length of the meta-event data.
  */
 int
-mf_write_midi_event (delta_time, type, chan, data, size)
-     unsigned long delta_time;
-     int chan, type;
-     unsigned long size;
-     char *data;
+mf_write_midi_event (unsigned long delta_time, int type, int chan,
+	char *data, unsigned long size)
 {
   int i;
   unsigned char c;
@@ -999,11 +971,9 @@ mf_write_midi_event (delta_time, type, chan, data, size)
  *        data.
  * size - The length of the meta-event data.
  */
-int 
-mf_write_meta_event (delta_time, type, data, size)
-     unsigned long delta_time;
-     unsigned char *data, type;
-     unsigned long size;
+int
+mf_write_meta_event (unsigned long delta_time, unsigned char type,
+	unsigned char *data, unsigned long size)
 {
   int i;
 
@@ -1027,9 +997,7 @@ mf_write_meta_event (delta_time, type, data, size)
 }				/* end mf_write_meta_event */
 
 void
-mf_write_tempo (delta_time, tempo)
-     unsigned long delta_time;
-     unsigned long tempo;
+mf_write_tempo (unsigned long delta_time, unsigned long tempo)
 {
   /* Write tempo */
   /* all tempos are written as 120 beats/minute, */
@@ -1046,9 +1014,7 @@ mf_write_tempo (delta_time, tempo)
 }
 
 void
-mf_write_seqnum (delta_time, seqnum)
-     unsigned long delta_time;
-     unsigned seqnum;
+mf_write_seqnum (unsigned long delta_time, unsigned int seqnum)
 {
 
   WriteVarLen (delta_time);
@@ -1060,10 +1026,7 @@ mf_write_seqnum (delta_time, seqnum)
 }
 
 unsigned long
-mf_sec2ticks (secs, division, tempo)
-     int division;
-     unsigned long tempo;
-     double secs;
+mf_sec2ticks (double secs, int division, unsigned long tempo)
 {
   return (unsigned long) (((secs * 1000.0) / 4.0 * division) / tempo);
 }
@@ -1072,8 +1035,7 @@ mf_sec2ticks (secs, division, tempo)
  * Write multi-length bytes to MIDI format files
  */
 void
-WriteVarLen (value)
-     unsigned long value;
+WriteVarLen (unsigned long value)
 {
   unsigned long buffer;
 
@@ -1102,10 +1064,7 @@ WriteVarLen (value)
  *
  */
 double
-mf_ticks2sec (ticks, division, tempo)
-     int division;
-     unsigned long tempo;
-     unsigned long ticks;
+mf_ticks2sec (unsigned long ticks, int division, unsigned long tempo)
 {
   double smpte_format, smpte_resolution;
 
@@ -1133,8 +1092,7 @@ mf_ticks2sec (ticks, division, tempo)
  *
  */
 void
-write32bit (data)
-     unsigned long data;
+write32bit (unsigned long data)
 {
   eputc ((unsigned) ((data >> 24) & 0xff));
   eputc ((unsigned) ((data >> 16) & 0xff));
@@ -1143,8 +1101,7 @@ write32bit (data)
 }
 
 void
-write16bit (data)
-     int data;
+write16bit (int data)
 {
   eputc ((unsigned) ((data & 0xff00) >> 8));
   eputc ((unsigned) (data & 0xff));
@@ -1152,8 +1109,7 @@ write16bit (data)
 
 /* write a single character and abort on error */
 static int
-eputc (c)
-     unsigned char c;
+eputc (unsigned char c)
 {
   int return_val;
 

--- a/test/midifile.h
+++ b/test/midifile.h
@@ -1,27 +1,27 @@
 /* definitions for MIDI file parsing code */
-extern int (*Mf_getc)();
-extern void (*Mf_header)();
-extern void (*Mf_trackstart)();
-extern void (*Mf_trackend)();
-extern void (*Mf_noteon)();
-extern void (*Mf_noteoff)();
-extern void (*Mf_pressure)();
-extern void (*Mf_parameter)();
-extern void (*Mf_pitchbend)();
-extern void (*Mf_program)();
-extern void (*Mf_chanpressure)();
-extern void (*Mf_sysex)();
-extern void (*Mf_metamisc)();
-extern void (*Mf_seqspecific)();
-extern void (*Mf_seqnum)();
-extern void (*Mf_text)();
-extern void (*Mf_eot)();
-extern void (*Mf_timesig)();
-extern void (*Mf_smpte)();
-extern void (*Mf_tempo)();
-extern void (*Mf_keysig)();
-extern void (*Mf_arbitrary)();
-extern void (*Mf_error)();
+extern int (*Mf_getc)(void);
+extern void (*Mf_error)(char *s);
+extern void (*Mf_header)(int format, int ntrks, int division);
+extern void (*Mf_trackstart)(void);
+extern void (*Mf_trackend)(void);
+extern void (*Mf_noteon)(int chan, int c1, int c2);
+extern void (*Mf_noteoff)(int chan, int c1, int c2);
+extern void (*Mf_pressure)(int chan, int c1, int c2);
+extern void (*Mf_parameter)(int chan, int c1, int c2);
+extern void (*Mf_pitchbend)(int chan, int c1, int c2);
+extern void (*Mf_program)(int chan, int c1);
+extern void (*Mf_chanpressure)(int chan, int c1);
+extern void (*Mf_sysex)(int len, char *msg);
+extern void (*Mf_arbitrary)(int len, char *msg);
+extern void (*Mf_metamisc)(int type, int len, char *msg);
+extern void (*Mf_seqnum)(int num);
+extern void (*Mf_eot)(void);
+extern void (*Mf_smpte)(char m0, char m1, char m2, char m3, char m4);
+extern void (*Mf_tempo)(long tempo);
+extern void (*Mf_timesig)(char m0, char m1, char m2, char m3);
+extern void (*Mf_keysig)(char m0, char m1);
+extern void (*Mf_seqspecific)(int len, char *msg);
+extern void (*Mf_text)(int type, int len, char *msg);
 extern unsigned long Mf_currtime;
 extern unsigned long Mf_realtime;
 extern unsigned long Mf_currtempo;
@@ -33,20 +33,23 @@ extern int Mf_file_size;
 #endif
 
 /* definitions for MIDI file writing code */
-extern int (*Mf_putc)();
-extern int (*Mf_writetrack)();
-extern int (*Mf_writetempotrack)();
+extern int (*Mf_putc)(unsigned char c);
+extern int (*Mf_writetrack)(int track);
+extern int (*Mf_writetempotrack)(void);
 
-extern void midifile();
-extern unsigned long mf_sec2ticks();
-extern void mfwrite();
-extern int mf_write_meta_event();
+extern void midifile(void);
+extern unsigned long mf_sec2ticks(double secs, int division,
+	unsigned long tempo);
+extern void mfwrite(int format, int ntracks, int division, FILE *fp);
+extern int mf_write_meta_event(unsigned long delta_time, unsigned char type,
+	unsigned char *data, unsigned long size);
 extern int mf_write_midi_event(unsigned long delta_time, int type,
 	int chan, char *data, unsigned long size);
-extern double mf_ticks2sec(unsigned long ticks,int division,unsigned long tempo);
-extern void mf_write_tempo();
-extern void mf_write_seqnum();
-extern void mfread();
+extern double mf_ticks2sec(unsigned long ticks, int division,
+	unsigned long tempo);
+extern void mf_write_tempo(unsigned long delta_time, unsigned long tempo);
+extern void mf_write_seqnum(unsigned long delta_time, unsigned int seqnum);
+extern void mfread(void);
 extern void mferror(char *s);
 
 #ifndef NO_LC_DEFINES

--- a/test/playmidi1.c
+++ b/test/playmidi1.c
@@ -243,14 +243,14 @@ static void alsa_stop_timer(void)
 }
 
 /* change the tempo */
-static void do_tempo(int us)
+static void do_tempo(long us)
 {
 	snd_seq_event_t ev;
 
 	if (verbose >= VERB_MUCH) {
 		double bpm;
 		bpm = 60.0E6 / (double) us;
-		printf("Tempo %d us/beat, %.2f bpm\n", us, bpm);
+		printf("Tempo %ld us/beat, %.2f bpm\n", us, bpm);
 	}
 
 	/* store the new tempo and timestamp of the tempo change */


### PR DESCRIPTION
The `midifile` library used by the `playmidi1` program dates from 1989, and used pre-ANSI function definitions and prototypes. GCC 15 now defaults to C23 where `()` means the same as `(void)` in prototypes, which causes type mismatch errors.

Update the code to use ANSI function definitions and prototypes, so it'll compile happily as anything from ANSI C to C23. This revealed that `playmidi1`'s `do_tempo` had the wrong argument type, so correct that as well.

Fixes #452.