### PR TITLE
conf/pistachio: fix syntax

### DIFF
--- a/src/conf/cards/pistachio-card.conf
+++ b/src/conf/cards/pistachio-card.conf
@@ -55,4 +55,5 @@ pistachio-card.pcm.default{
                 type hw
                 card $CARD
                 device $DEVICE
-
+        }
+}


### PR DESCRIPTION
It was missing closing brackets since its introduction.

Fixes: 4dfa8f08fb83 ("conf/cards: add support for pistachio-card.")