### PR TITLE
tlv: ignore xdir when type is DB_MINMAX_MUTE

### DIFF
--- a/src/control/tlv.c
+++ b/src/control/tlv.c
@@ -369,7 +369,7 @@ int snd_tlv_convert_from_dB(unsigned int *tlv, long rangemin, long rangemax,
 		min = tlv[SNDRV_CTL_TLVO_DB_MINMAX_MIN];
 		max = tlv[SNDRV_CTL_TLVO_DB_MINMAX_MAX];
 		if (db_gain <= min)
-			if (db_gain > SND_CTL_TLV_DB_GAIN_MUTE && xdir > 0 &&
+			if (db_gain > SND_CTL_TLV_DB_GAIN_MUTE &&
 			    type == SND_CTL_TLVT_DB_MINMAX_MUTE)
 				*value = rangemin + 1;
 			else


### PR DESCRIPTION
Muting caused by rounding is meaningless, and it is also inconvenient for upper-layer applications to handling muting issues caused by DB_MINMAX_MUTE or xdir. Thus, the restriction on xdir is removed.