### PR TITLE
snd_tlv_convert_to_dB: Fix mute handling for MINMAX_MUTE type

### DIFF
--- a/src/control/tlv.c
+++ b/src/control/tlv.c
@@ -246,16 +246,17 @@ int snd_tlv_convert_to_dB(unsigned int *tlv, long rangemin, long rangemax,
 		int mindb, maxdb;
 		mindb = tlv[SNDRV_CTL_TLVO_DB_MINMAX_MIN];
 		maxdb = tlv[SNDRV_CTL_TLVO_DB_MINMAX_MAX];
-		if (volume <= rangemin || rangemax <= rangemin) {
-			if (type == SND_CTL_TLVT_DB_MINMAX_MUTE)
-				*db_gain = SND_CTL_TLV_DB_GAIN_MUTE;
-			else
-				*db_gain = mindb;
-		} else if (volume >= rangemax)
-			*db_gain = maxdb;
+		if (rangemax <= rangemin)
+			*db_gain = mindb;
 		else
 			*db_gain = (maxdb - mindb) * (volume - rangemin) /
 				(rangemax - rangemin) + mindb;
+		if (*db_gain < mindb)
+			*db_gain = mindb;
+		if (*db_gain > maxdb)
+			*db_gain = maxdb;
+		if (type == SND_CTL_TLVT_DB_MINMAX_MUTE && *db_gain == mindb)
+			*db_gain = SND_CTL_TLV_DB_GAIN_MUTE;
 		return 0;
 	}
 #ifndef HAVE_SOFT_FLOAT


### PR DESCRIPTION
Ensure the SND_CTL_TLV_DB_GAIN_MUTE value is returned when the calculated gain equals the minimum dB value for the SNDRV_CTL_TLVT_DB_MINMAX_MUTE type. The previous check based solely on the volume value could miss cases where the linear calculation resulted in the minimum gain.

The db range of some devices is very small

<img width="619" height="106" alt="17574693041385" src="https://github.com/user-attachments/assets/3461c643-284d-4ef0-8315-8fc682688442" />
