### PR TITLE
doxygen: fix for doxygen 1.10.0 and later

### DIFF
--- a/doc/doxygen.cfg.in
+++ b/doc/doxygen.cfg.in
@@ -16,6 +16,7 @@ INPUT            = @top_srcdir@/doc/index.doxygen \
 		   @top_srcdir@/include/conf.h \
 		   @top_srcdir@/include/control.h \
 		   @top_srcdir@/include/pcm.h \
+		   @top_srcdir@/include/pcm_plugin.h \
 		   @top_srcdir@/include/rawmidi.h \
 		   @top_srcdir@/include/ump.h \
 		   @top_srcdir@/include/ump_msg.h \
@@ -129,6 +130,7 @@ MACRO_EXPANSION  = YES
 EXPAND_ONLY_PREDEF = YES
 PREDEFINED	 = DOXYGEN PIC "DOC_HIDDEN" \
 		   "ATTRIBUTE_UNUSED=" \
+		   ALSA_LIBRARY_BUILD \
 		   ALSA_PCM_NEW_HW_PARAMS_API \
 		   _POSIX_C_SOURCE \
 		   "use_default_symbol_version(x,y,z)=" \
@@ -137,7 +139,7 @@ PREDEFINED	 = DOXYGEN PIC "DOC_HIDDEN" \
 
 OPTIMIZE_OUTPUT_FOR_C = YES	# doxygen 1.2.6 option
 TYPEDEF_HIDES_STRUCT = YES	# needed in doxygen >= 1.5.4
-
+SORT_GROUP_NAMES = YES
 #INPUT_FILTER	 = inputfilter
 #FILTER_SOURCE_FILES = YES
 

--- a/include/asoundef.h
+++ b/include/asoundef.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_ASOUNDEF_H
+#define __ALSA_ASOUNDEF_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/asoundef.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_ASOUNDEF_H
-#define __ALSA_ASOUNDEF_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/conf.h
+++ b/include/conf.h
@@ -25,13 +25,13 @@
  *
  */
 
+#ifndef __ALSA_CONF_H
+#define __ALSA_CONF_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_CONF_H
-#define __ALSA_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,7 +108,7 @@ void snd_config_unref(snd_config_t *top);
 
 int snd_config_search(snd_config_t *config, const char *key,
 		      snd_config_t **result);
-int snd_config_searchv(snd_config_t *config, 
+int snd_config_searchv(snd_config_t *config,
 		       snd_config_t **result, ...);
 int snd_config_search_definition(snd_config_t *config,
 				 const char *base, const char *key,
@@ -122,7 +122,7 @@ int snd_config_search_definition(snd_config_t *config,
  * \param[in] private_data Handle to the \c private_data node.
  * \return A non-negative value if successful, otherwise a negative error code.
  *
- * Use a function of this type to define a custom expansion 
+ * Use a function of this type to define a custom expansion
  */
 typedef int (*snd_config_expand_fcn_t)(snd_config_t **dst, const char *s, void *private_data);
 

--- a/include/control.h
+++ b/include/control.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_CONTROL_H
+#define __ALSA_CONTROL_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/control.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_CONTROL_H
-#define __ALSA_CONTROL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -386,7 +386,7 @@ int snd_ctl_open_fallback(snd_ctl_t **ctl, snd_config_t *root, const char *name,
 int snd_ctl_close(snd_ctl_t *ctl);
 int snd_ctl_nonblock(snd_ctl_t *ctl, int nonblock);
 static __inline__ int snd_ctl_abort(snd_ctl_t *ctl) { return snd_ctl_nonblock(ctl, 2); }
-int snd_async_add_ctl_handler(snd_async_handler_t **handler, snd_ctl_t *ctl, 
+int snd_async_add_ctl_handler(snd_async_handler_t **handler, snd_ctl_t *ctl,
 			      snd_async_callback_t callback, void *private_data);
 snd_ctl_t *snd_async_handler_get_ctl(snd_async_handler_t *handler);
 int snd_ctl_poll_descriptors_count(snd_ctl_t *ctl);
@@ -718,7 +718,7 @@ typedef int (*snd_hctl_compare_t)(const snd_hctl_elem_t *e1,
 				  const snd_hctl_elem_t *e2);
 int snd_hctl_compare_fast(const snd_hctl_elem_t *c1,
 			  const snd_hctl_elem_t *c2);
-/** 
+/**
  * \brief HCTL callback function
  * \param hctl HCTL handle
  * \param mask event mask
@@ -728,7 +728,7 @@ int snd_hctl_compare_fast(const snd_hctl_elem_t *c1,
 typedef int (*snd_hctl_callback_t)(snd_hctl_t *hctl,
 				   unsigned int mask,
 				   snd_hctl_elem_t *elem);
-/** 
+/**
  * \brief HCTL element callback function
  * \param elem HCTL element
  * \param mask event mask

--- a/include/error.h
+++ b/include/error.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_ERROR_H
+#define __ALSA_ERROR_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/error.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_ERROR_H
-#define __ALSA_ERROR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/global.h
+++ b/include/global.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_GLOBAL_H_
+#define __ALSA_GLOBAL_H_
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/global.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_GLOBAL_H_
-#define __ALSA_GLOBAL_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -124,7 +124,7 @@ typedef struct _snd_async_handler snd_async_handler_t;
  */
 typedef void (*snd_async_callback_t)(snd_async_handler_t *handler);
 
-int snd_async_add_handler(snd_async_handler_t **handler, int fd, 
+int snd_async_add_handler(snd_async_handler_t **handler, int fd,
 			  snd_async_callback_t callback, void *private_data);
 int snd_async_del_handler(snd_async_handler_t *handler);
 int snd_async_handler_get_fd(snd_async_handler_t *handler);

--- a/include/hwdep.h
+++ b/include/hwdep.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_HWDEP_H
+#define __ALSA_HWDEP_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/hwdep.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_HWDEP_H
-#define __ALSA_HWDEP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_MIXER_H
+#define __ALSA_MIXER_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/mixer.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_MIXER_H
-#define __ALSA_MIXER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,7 +51,7 @@ typedef struct _snd_mixer_class snd_mixer_class_t;
 /** Mixer element handle */
 typedef struct _snd_mixer_elem snd_mixer_elem_t;
 
-/** 
+/**
  * \brief Mixer callback function
  * \param ctl Mixer handle
  * \param mask event mask
@@ -62,7 +62,7 @@ typedef int (*snd_mixer_callback_t)(snd_mixer_t *ctl,
 				    unsigned int mask,
 				    snd_mixer_elem_t *elem);
 
-/** 
+/**
  * \brief Mixer element callback function
  * \param elem Mixer element
  * \param mask event mask
@@ -276,17 +276,17 @@ int snd_mixer_selem_set_playback_switch(snd_mixer_elem_t *elem, snd_mixer_selem_
 int snd_mixer_selem_set_capture_switch(snd_mixer_elem_t *elem, snd_mixer_selem_channel_id_t channel, int value);
 int snd_mixer_selem_set_playback_switch_all(snd_mixer_elem_t *elem, int value);
 int snd_mixer_selem_set_capture_switch_all(snd_mixer_elem_t *elem, int value);
-int snd_mixer_selem_get_playback_volume_range(snd_mixer_elem_t *elem, 
+int snd_mixer_selem_get_playback_volume_range(snd_mixer_elem_t *elem,
 					      long *min, long *max);
-int snd_mixer_selem_get_playback_dB_range(snd_mixer_elem_t *elem, 
+int snd_mixer_selem_get_playback_dB_range(snd_mixer_elem_t *elem,
 					  long *min, long *max);
-int snd_mixer_selem_set_playback_volume_range(snd_mixer_elem_t *elem, 
+int snd_mixer_selem_set_playback_volume_range(snd_mixer_elem_t *elem,
 					      long min, long max);
-int snd_mixer_selem_get_capture_volume_range(snd_mixer_elem_t *elem, 
+int snd_mixer_selem_get_capture_volume_range(snd_mixer_elem_t *elem,
 					     long *min, long *max);
-int snd_mixer_selem_get_capture_dB_range(snd_mixer_elem_t *elem, 
+int snd_mixer_selem_get_capture_dB_range(snd_mixer_elem_t *elem,
 					 long *min, long *max);
-int snd_mixer_selem_set_capture_volume_range(snd_mixer_elem_t *elem, 
+int snd_mixer_selem_set_capture_volume_range(snd_mixer_elem_t *elem,
 					     long min, long max);
 
 int snd_mixer_selem_is_enumerated(snd_mixer_elem_t *elem);

--- a/include/pcm.h
+++ b/include/pcm.h
@@ -26,14 +26,14 @@
  *
  */
 
+#ifndef __ALSA_PCM_H
+#define __ALSA_PCM_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/pcm.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_PCM_H
-#define __ALSA_PCM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -303,7 +303,7 @@ typedef enum _snd_pcm_subformat {
 typedef enum _snd_pcm_state {
 	/** Open */
 	SND_PCM_STATE_OPEN = 0,
-	/** Setup installed */ 
+	/** Setup installed */
 	SND_PCM_STATE_SETUP,
 	/** Ready to start */
 	SND_PCM_STATE_PREPARED,
@@ -525,9 +525,9 @@ typedef union _snd_pcm_sync_id {
 /** #SND_PCM_TYPE_METER scope handle */
 typedef struct _snd_pcm_scope snd_pcm_scope_t;
 
-int snd_pcm_open(snd_pcm_t **pcm, const char *name, 
+int snd_pcm_open(snd_pcm_t **pcm, const char *name,
 		 snd_pcm_stream_t stream, int mode);
-int snd_pcm_open_lconf(snd_pcm_t **pcm, const char *name, 
+int snd_pcm_open_lconf(snd_pcm_t **pcm, const char *name,
 		       snd_pcm_stream_t stream, int mode,
 		       snd_config_t *lconf);
 int snd_pcm_open_fallback(snd_pcm_t **pcm, snd_config_t *root,
@@ -543,7 +543,7 @@ int snd_pcm_poll_descriptors(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int s
 int snd_pcm_poll_descriptors_revents(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int nfds, unsigned short *revents);
 int snd_pcm_nonblock(snd_pcm_t *pcm, int nonblock);
 static __inline__ int snd_pcm_abort(snd_pcm_t *pcm) { return snd_pcm_nonblock(pcm, 2); }
-int snd_async_add_pcm_handler(snd_async_handler_t **handler, snd_pcm_t *pcm, 
+int snd_async_add_pcm_handler(snd_async_handler_t **handler, snd_pcm_t *pcm,
 			      snd_async_callback_t callback, void *private_data);
 snd_pcm_t *snd_async_handler_get_pcm(snd_async_handler_t *handler);
 int snd_pcm_info(snd_pcm_t *pcm, snd_pcm_info_t *info);
@@ -1149,7 +1149,7 @@ snd_pcm_sframes_t snd_pcm_mmap_commit(snd_pcm_t *pcm,
 snd_pcm_sframes_t snd_pcm_mmap_writei(snd_pcm_t *pcm, const void *buffer, snd_pcm_uframes_t size);
 snd_pcm_sframes_t snd_pcm_mmap_readi(snd_pcm_t *pcm, void *buffer, snd_pcm_uframes_t size);
 snd_pcm_sframes_t snd_pcm_mmap_writen(snd_pcm_t *pcm, void **bufs, snd_pcm_uframes_t size);
-snd_pcm_sframes_t snd_pcm_mmap_readn(snd_pcm_t *pcm, void **bufs, snd_pcm_uframes_t size);                                                                
+snd_pcm_sframes_t snd_pcm_mmap_readn(snd_pcm_t *pcm, void **bufs, snd_pcm_uframes_t size);
 
 /** \} */
 

--- a/include/pcm_extplug.h
+++ b/include/pcm_extplug.h
@@ -28,13 +28,13 @@
  *
  */
 
+#ifndef __ALSA_PCM_EXTPLUG_H
+#define __ALSA_PCM_EXTPLUG_H
+
 #if !defined(__ALSA_PCM_EXTERNAL_H) && !defined(ALSA_LIBRARY_BUILD)
 #warning "use #include <alsa/pcm_external.h>, <alsa/pcm_extplug.h> should not be used directly"
 #include <alsa/pcm_external.h>
 #endif
-
-#ifndef __ALSA_PCM_EXTPLUG_H
-#define __ALSA_PCM_EXTPLUG_H
 
 /**
  * \defgroup PCM_ExtPlug External Filter plugin SDK
@@ -49,7 +49,7 @@ enum {
 	SND_PCM_EXTPLUG_HW_CHANNELS,	/**< channels */
 	SND_PCM_EXTPLUG_HW_PARAMS	/**< max number of hw constraints */
 };
-	
+
 /** Handle of external filter plugin */
 typedef struct snd_pcm_extplug snd_pcm_extplug_t;
 /** Callback table of extplug */

--- a/include/pcm_ioplug.h
+++ b/include/pcm_ioplug.h
@@ -28,13 +28,13 @@
  *
  */
 
+#ifndef __ALSA_PCM_IOPLUG_H
+#define __ALSA_PCM_IOPLUG_H
+
 #if !defined(__ALSA_PCM_EXTERNAL_H) && !defined(ALSA_LIBRARY_BUILD)
 #warning "use #include <alsa/pcm_external.h>, <alsa/pcm_ioplug.h> should not be used directly"
 #include <alsa/pcm_external.h>
 #endif
-
-#ifndef __ALSA_PCM_IOPLUG_H
-#define __ALSA_PCM_IOPLUG_H
 
 /**
  * \defgroup PCM_IOPlug External I/O plugin SDK
@@ -54,7 +54,7 @@ enum {
 	SND_PCM_IOPLUG_HW_PERIODS,	/**< number of periods */
 	SND_PCM_IOPLUG_HW_PARAMS	/**< max number of hw constraints */
 };
-	
+
 /** I/O plugin handle */
 typedef struct snd_pcm_ioplug snd_pcm_ioplug_t;
 /** Callback table of ioplug */
@@ -114,7 +114,7 @@ struct snd_pcm_ioplug {
 	 */
 	snd_pcm_t *pcm;
 
-	snd_pcm_stream_t stream;	/**< stream direcion; read-only */	
+	snd_pcm_stream_t stream;	/**< stream direcion; read-only */
 	snd_pcm_state_t state;		/**< current PCM state; read-only */
 	volatile snd_pcm_uframes_t appl_ptr;	/**< application pointer; read-only */
 	volatile snd_pcm_uframes_t hw_ptr;	/**< hw pointer; read-only */

--- a/include/pcm_plugin.h
+++ b/include/pcm_plugin.h
@@ -38,7 +38,7 @@
  * See the \ref pcm_plugins page for more details.
  * \{
  */
-  
+
 #define SND_PCM_PLUGIN_RATE_MIN 4000	/**< minimal rate for the rate plugin */
 #define SND_PCM_PLUGIN_RATE_MAX 768000	/**< maximal rate for the rate plugin */
 
@@ -82,7 +82,7 @@ int snd_pcm_copy_open(snd_pcm_t **pcmp, const char *name,
 int _snd_pcm_copy_open(snd_pcm_t **pcmp, const char *name,
 		       snd_config_t *root, snd_config_t *conf,
                        snd_pcm_stream_t stream, int mode);
-                                              
+
 /*
  *  Linear conversion plugin
  */
@@ -198,18 +198,6 @@ int snd_pcm_ladspa_open(snd_pcm_t **pcmp, const char *name,
 int _snd_pcm_ladspa_open(snd_pcm_t **pcmp, const char *name,
 			 snd_config_t *root, snd_config_t *conf,
 			 snd_pcm_stream_t stream, int mode);
-
-/*
- *  Jack plugin
- */
-int snd_pcm_jack_open(snd_pcm_t **pcmp, const char *name,
-					snd_config_t *playback_conf,
-					snd_config_t *capture_conf,
-		      snd_pcm_stream_t stream, int mode);
-int _snd_pcm_jack_open(snd_pcm_t **pcmp, const char *name,
-                       snd_config_t *root, snd_config_t *conf,
-                       snd_pcm_stream_t stream, int mode);
-
 
 /** \} */
 

--- a/include/rawmidi.h
+++ b/include/rawmidi.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_RAWMIDI_H
+#define __ALSA_RAWMIDI_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/rawmidi.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_RAWMIDI_H
-#define __ALSA_RAWMIDI_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/seq.h
+++ b/include/seq.h
@@ -26,14 +26,14 @@
  *
  */
 
+#ifndef __ALSA_SEQ_H
+#define __ALSA_SEQ_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/seq.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_SEQ_H
-#define __ALSA_SEQ_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -135,7 +135,7 @@ typedef enum snd_seq_client_type {
 	SND_SEQ_USER_CLIENT     = 1,	/**< user client */
 	SND_SEQ_KERNEL_CLIENT   = 2	/**< kernel client */
 } snd_seq_client_type_t;
-                        
+
 /** client MIDI version */
 enum {
 	SND_SEQ_CLIENT_LEGACY_MIDI = 0,		/**< Legacy client */

--- a/include/seq_event.h
+++ b/include/seq_event.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_SEQ_EVENT_H
+#define __ALSA_SEQ_EVENT_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/seq_event.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_SEQ_EVENT_H
-#define __ALSA_SEQ_EVENT_H
 
 /**
  *  \defgroup SeqEvents Sequencer Event Definitions
@@ -61,7 +61,7 @@ enum snd_seq_event_type {
 	SND_SEQ_EVENT_NOTEOFF,
 	/** key pressure change (aftertouch); event data type = #snd_seq_ev_note_t */
 	SND_SEQ_EVENT_KEYPRESS,
-	
+
 	/** controller; event data type = #snd_seq_ev_ctrl_t */
 	SND_SEQ_EVENT_CONTROLLER = 10,
 	/** program change; event data type = #snd_seq_ev_ctrl_t */
@@ -87,7 +87,7 @@ enum snd_seq_event_type {
 	SND_SEQ_EVENT_TIMESIGN,
 	/** SMF Key Signature event; event data type = #snd_seq_ev_ctrl_t */
 	SND_SEQ_EVENT_KEYSIGN,
-	        
+
 	/** MIDI Real Time Start message; event data type = #snd_seq_ev_queue_control_t */
 	SND_SEQ_EVENT_START = 30,
 	/** MIDI Real Time Continue message; event data type = #snd_seq_ev_queue_control_t */
@@ -329,7 +329,7 @@ typedef struct snd_seq_event {
 	snd_seq_event_type_t type;	/**< event type */
 	unsigned char flags;		/**< event flags */
 	unsigned char tag;		/**< tag */
-	
+
 	unsigned char queue;		/**< schedule queue */
 	snd_seq_timestamp_t time;	/**< schedule time */
 

--- a/include/seqmid.h
+++ b/include/seqmid.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_SEQMID_H
+#define __ALSA_SEQMID_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/seqmid.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_SEQMID_H
-#define __ALSA_SEQMID_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,7 +48,7 @@ extern "C" {
 /**
  * \brief initialize event record
  * \param ev event record pointer
- * 
+ *
  * This macro clears the given event record pointer to the default status.
  */
 static inline void snd_seq_ev_clear(snd_seq_event_t *ev)
@@ -130,7 +130,7 @@ static inline void snd_seq_ump_ev_clear(snd_seq_ump_event_t *ev)
  *
  * This macro sets the event to the direct passing mode
  * to be delivered immediately without queueing.
- * 
+ *
  * \sa snd_seq_ev_schedule_tick(), snd_seq_ev_schedule_real()
  */
 #define snd_seq_ev_set_direct(ev) \

--- a/include/timer.h
+++ b/include/timer.h
@@ -25,14 +25,14 @@
  *
  */
 
+#ifndef __ALSA_TIMER_H
+#define __ALSA_TIMER_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/timer.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_TIMER_H
-#define __ALSA_TIMER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -99,7 +99,7 @@ typedef enum _snd_timer_event {
 	SND_TIMER_EVENT_MCONTINUE = SND_TIMER_EVENT_CONTINUE + 10,
 	SND_TIMER_EVENT_MPAUSE = SND_TIMER_EVENT_PAUSE + 10,
 	SND_TIMER_EVENT_MSUSPEND = SND_TIMER_EVENT_SUSPEND + 10,
-	SND_TIMER_EVENT_MRESUME = SND_TIMER_EVENT_RESUME + 10	
+	SND_TIMER_EVENT_MRESUME = SND_TIMER_EVENT_RESUME + 10
 } snd_timer_event_t;
 
 /** timer read structure */

--- a/include/ump.h
+++ b/include/ump.h
@@ -6,14 +6,14 @@
  * API library for ALSA rawmidi/UMP interface
  */
 
+#ifndef __ALSA_UMP_H
+#define __ALSA_UMP_H
+
 #if !defined(__ASOUNDLIB_H) && !defined(ALSA_LIBRARY_BUILD)
 /* don't use ALSA_LIBRARY_BUILD define in sources outside alsa-lib */
 #warning "use #include <alsa/asoundlib.h>, <alsa/ump.h> should not be used directly"
 #include <alsa/asoundlib.h>
 #endif
-
-#ifndef __ALSA_UMP_H
-#define __ALSA_UMP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pcm/pcm_hw.c
+++ b/src/pcm/pcm_hw.c
@@ -26,7 +26,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-  
+
 #include "pcm_local.h"
 #include "../control/control_local.h"
 #include "../timer/timer_local.h"
@@ -375,12 +375,14 @@ static int snd_pcm_hw_hw_refine(snd_pcm_t *pcm, snd_pcm_hw_params_t *params)
 		if (pcm->tstamp_type != SND_PCM_TSTAMP_TYPE_GETTIMEOFDAY)
 			params->info |= SND_PCM_INFO_MONOTONIC;
 	}
-	
+
 	return 0;
 }
 
+#ifndef DOC_HIDDEN
 #define hw_param_mask(params,var) \
 	&((params)->masks[(var) - SND_PCM_HW_PARAM_FIRST_MASK])
+#endif
 
 static int hw_params_call(snd_pcm_hw_t *pcm_hw, snd_pcm_hw_params_t *params)
 {
@@ -434,7 +436,7 @@ static int snd_pcm_hw_change_timer(snd_pcm_t *pcm, int enable)
 	snd_timer_params_t params = {0};
 	unsigned int suspend, resume;
 	int err;
-	
+
 	if (enable) {
 		err = snd_timer_hw_open(&hw->period_timer,
 				"hw-pcm-period-event",
@@ -1689,7 +1691,7 @@ int snd_pcm_hw_open_fd(snd_pcm_t **pcmp, const char *name, int fd,
 			return ret;
 		}
 	}
-	
+
 	hw = calloc(1, sizeof(snd_pcm_hw_t));
 	if (!hw) {
 		close(fd);
@@ -2150,7 +2152,7 @@ static int use_old_hw_params_ioctl(int fd, unsigned int cmd, snd_pcm_hw_params_t
 	struct sndrv_pcm_hw_params_old oparams;
 	unsigned int cmask = 0;
 	int res;
-	
+
 	snd_pcm_hw_convert_to_old_params(&oparams, params, &cmask);
 	res = ioctl(fd, cmd, &oparams);
 	snd_pcm_hw_convert_from_old_params(params, &oparams);


### PR DESCRIPTION
doygen 1.10.0 changed the paths that include files are searched, with the consequence for alsa-lib that the "Topics" tab is no longer fully populated.

See for example the [alsa project online docs](https://www.alsa-project.org/alsa-doc/alsa-lib/topics.html)

To fix this we need to prevent circular #include references when doygen scans its input files, and also to re-order some macros.