### PR TITLE
ucm: use closefrom instead of close_range

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ dnl Checks for library functions.
 AC_PROG_GCC_TRADITIONAL
 AC_CHECK_FUNCS([uselocale])
 AC_CHECK_FUNCS([eaccess])
+AC_CHECK_DECLS([closefrom])
 
 dnl Enable largefile support
 AC_SYS_LARGEFILE

--- a/src/ucm/ucm_exec.c
+++ b/src/ucm/ucm_exec.c
@@ -259,8 +259,8 @@ int uc_mgr_exec(const char *prog)
 
 		close(f);
 
-#if defined(_GNU_SOURCE)
-		close_range(3, maxfd, 0);
+#if HAVE_DECL_CLOSEFROM
+		closefrom(3);
 #else
 		for (f = 3; f < maxfd; f++)
 			close(f);


### PR DESCRIPTION
closefrom is a library function with a fallback mechanism for when the kernel does not support the close_range syscall.

Also check for the function properly instead of assuming it is available with _GNU_SOURCE defined.

Fixes: https://github.com/alsa-project/alsa-lib/issues/485