### PR TITLE
mixer: fix cache coherency issue in multi-application scenario

### DIFF
--- a/src/mixer/simple_none.c
+++ b/src/mixer/simple_none.c
@@ -1262,9 +1262,7 @@ static int set_volume_ops(snd_mixer_elem_t *elem, int dir,
 	changed = _snd_mixer_selem_set_volume(elem, dir, channel, value);
 	if (changed < 0)
 		return changed;
-	if (changed)
-		return selem_write(elem);
-	return 0;
+	return selem_write(elem);
 }
 
 static int ask_dB_vol_ops(snd_mixer_elem_t *elem, int dir,
@@ -1318,9 +1316,7 @@ static int set_switch_ops(snd_mixer_elem_t *elem, int dir,
 	changed = _snd_mixer_selem_set_switch(elem, dir, channel, value);
 	if (changed < 0)
 		return changed;
-	if (changed)
-		return selem_write(elem);
-	return 0;
+	return selem_write(elem);
 }
 
 static int enum_item_name_ops(snd_mixer_elem_t *elem,


### PR DESCRIPTION
Remove conditional hardware writes in set_volume_ops and set_switch_ops to ensure hardware state is always updated. This fixes an issue where setting controls to the same value repeatedly does nothing, even if the hardware state has changed due to actions from other applications.

---

Given this code has been in alsa-lib for 20 years, I assume there is a good reason for it, or perhaps a workaround exists that I could not find. 

The issue we faced is that after an initial write, if the same value is written again, but in the meantime a different application altered the hardware state, the new change will not occur, yet no error code is provided. Also, reading the current state returns the current application's state, rather than the actual hardware state. Is alsa-lib not designed with multi-application uses in mind?