### PR TITLE
fix discards const from pointer target

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -4443,7 +4443,7 @@ int snd_config_hook_load_for_all_cards(snd_config_t *root, snd_config_t *config,
 					goto __err;
 				}
 				while (1) {
-					char *s = strchr(driver, '.');
+					const char *s = strchr(driver, '.');
 					if (s == NULL)
 						break;
 					driver = s + 1;

--- a/src/seq/seqmid.c
+++ b/src/seq/seqmid.c
@@ -424,8 +424,8 @@ int snd_seq_sync_output_queue(snd_seq_t *seq)
  */
 int snd_seq_parse_address(snd_seq_t *seq, snd_seq_addr_t *addr, const char *arg)
 {
-	char *p, *buf;
-	const char *s;
+	char *buf;
+	const char *p, *s;
 	char c;
 	long client, port = 0;
 	int len;

--- a/src/ucm/main.c
+++ b/src/ucm/main.c
@@ -2379,7 +2379,8 @@ int snd_use_case_get_list(snd_use_case_mgr_t *uc_mgr,
 			  const char *identifier,
 			  const char **list[])
 {
-	char *str, *str1;
+	char *str;
+	const char *str1;
 	int err, i;
 
 	if (uc_mgr == NULL || identifier == NULL) {
@@ -2712,7 +2713,8 @@ int snd_use_case_geti(snd_use_case_mgr_t *uc_mgr,
 		      const char *identifier,
 		      long *value)
 {
-	char *str, *str1;
+	char *str;
+	const char *str1;
 	int err;
 
 	pthread_mutex_lock(&uc_mgr->mutex);
@@ -3014,7 +3016,8 @@ int snd_use_case_set(snd_use_case_mgr_t *uc_mgr,
 		     const char *identifier,
 		     const char *value)
 {
-	char *str, *str1;
+	char *str;
+	const char *str1;
 	int err = 0;
 
 	snd_trace(UCM, "{API call} set '%s'='%s'", identifier, value);

--- a/src/ucm/ucm_subs.c
+++ b/src/ucm/ucm_subs.c
@@ -826,7 +826,7 @@ static int rval_evali(snd_use_case_mgr_t *uc_mgr, snd_config_t *node, const char
  */
 static inline const char *strchr_with_escape(const char *str, char c)
 {
-	char *s;
+	const char *s;
 
 	while (1) {
 		s = strchr(str, c);


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

fixes:
```c

../../../src/seq/seqmid.c: In function 'snd_seq_parse_address':
../../../src/seq/seqmid.c:449:24: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  449 |                 if ((p = strpbrk(arg, ":.")) != NULL) {
      |                        ^
../../../src/ucm/main.c: In function 'snd_use_case_get_list':
../../../src/ucm/main.c:2396:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2396 |                 str1 = strchr(identifier, '/');
      |                      ^
../../../src/ucm/main.c: In function 'snd_use_case_geti':
../../../src/ucm/main.c:2721:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2721 |                 str1 = strchr(identifier, '/');
      |                      ^
../../../src/ucm/main.c: In function 'snd_use_case_set':
../../../src/ucm/main.c:3038:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 3038 |                 str1 = strchr(identifier, '/');
      |                      ^
../../../src/ucm/ucm_subs.c: In function 'strchr_with_escape':
../../../src/ucm/ucm_subs.c:832:19: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  832 |                 s = strchr(str, c);
      |                   ^
../../src/conf.c: In function 'snd_config_hook_load_for_all_cards':
../../src/conf.c:4446:51: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 4446 |                                         char *s = strchr(driver, '.');
      |                                                   ^~~~~~

``` 