### PR TITLE
topology: decoder: fix wrong sizeof for enum control allocation in dapm

### DIFF
--- a/src/topology/dapm.c
+++ b/src/topology/dapm.c
@@ -983,7 +983,7 @@ next:
 							 bin, size2);
 			break;
 		case SND_SOC_TPLG_TYPE_ENUM:
-			et = tplg_calloc(&heap, sizeof(*mt));
+			et = tplg_calloc(&heap, sizeof(*et));
 			if (et == NULL) {
 				err = -ENOMEM;
 				goto retval;


### PR DESCRIPTION
The tplg_calloc() call for enum control in the dapm widget kcontrol decode loop used sizeof(*mt) (mixer template) instead of sizeof(*et) (enum template). On 64-bit systems, snd_tplg_mixer_template is 72 bytes while snd_tplg_enum_template is 80 bytes, causing an 8-byte heap buffer overflow when the enum fields (texts, values pointers) were written past the allocated block. This resulted in heap corruption and e.g. glibc malloc hit an assert.