### PR TITLE
Fix theoretical one-byte buffer overrun

### DIFF
--- a/src/control/ctlparse.c
+++ b/src/control/ctlparse.c
@@ -173,7 +173,7 @@ int __snd_ctl_ascii_elem_id_parse(snd_ctl_elem_id_t *dst, const char *str,
 			ptr = buf;
 			size = 0;
 			while (*str && *str != ',') {
-				if (size < (int)sizeof(buf)) {
+				if (size < (int)sizeof(buf) - 1) {
 					*ptr++ = *str;
 					size++;
 				}


### PR DESCRIPTION
If 64 (sizeof(buf))= or more characters were provided in the input string, this unconditionally writes a null byte to `buf[64]`, which is one byte past the end of the array.